### PR TITLE
For Alpha 19

### DIFF
--- a/.github/workflows/job-verification.yml
+++ b/.github/workflows/job-verification.yml
@@ -91,6 +91,16 @@ jobs:
             exit 1
           fi
 
+      - name: Run JSDoc @since test
+        id: jsdoc-since-test
+        run: |
+          if pnpm run coherency:jsdoc-since; then
+            echo "status=success" >> $GITHUB_OUTPUT
+          else
+            echo "status=failure" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
       - name: Run post-build smoke tests
         id: smoke-test
         run: |
@@ -109,6 +119,7 @@ jobs:
                 "${{ steps.category-test.outputs.status }}" == "success" && \
                 "${{ steps.dependencies-test.outputs.status }}" == "success" && \
                 "${{ steps.bundle-sizes-test.outputs.status }}" == "success" && \
+                "${{ steps.jsdoc-since-test.outputs.status }}" == "success" && \
                 "${{ steps.smoke-test.outputs.status }}" == "success" ]]; then
             echo "status=success" >> $GITHUB_OUTPUT
           else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ helpers/<category>/
 
 **TypeScript rules:**
 - `any` is **FORBIDDEN** — use `unknown` or specific types
-- JSDoc required on all exports: `@param`, `@returns`, `@example`
+- JSDoc required on all exports: `@param`, `@returns`, `@example`, `@since next`
 - 2-space indentation, single quotes
 - Tree-shakable exports only (no side effects)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Create `helpers/<category>/functionName.ts`:
  * @example
  * clamp(15, 0, 10)
  * // => 10
- * @since 2.0.0
+ * @since next
  */
 export function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
@@ -68,7 +68,8 @@ export function clamp(value: number, min: number, max: number): number {
 - **No side effects** — pure functions only
 - Use `readonly` arrays in parameters when the function does not mutate
 - 2-space indentation, single quotes
-- Target the current version for `@since` (check `package.json`)
+- Always use `@since next` — the real version is injected automatically at stable release time
+  (prerelease builds keep `next` so the tag retains its semantic meaning)
 
 ### Step 2 — Tests
 
@@ -321,7 +322,7 @@ Before opening a PR, make sure:
 
 - [ ] One function per file, in the correct category
 - [ ] License header present on all new files
-- [ ] JSDoc with `@param`, `@returns`, `@example`, `@since`
+- [ ] JSDoc with `@param`, `@returns`, `@example`, `@since next`
 - [ ] No `any` — use `unknown` or specific types
   - [ ] Tests with **100% coverage** (lines, functions, branches, statements)
   - [ ] Property-based + contract spec file (`functionName.spec.ts`)

--- a/docs/native-alternatives.json
+++ b/docs/native-alternatives.json
@@ -325,17 +325,6 @@
       "notes": "Too niche, use instanceof directly"
     },
     {
-      "name": "isArrayBuffer / isBlob / isBuffer / isFormData",
-      "libraries": [
-        "lodash",
-        "sindresorhus/is"
-      ],
-      "native": "value instanceof ArrayBuffer / Blob / Buffer / FormData",
-      "since": "ES2015 / Web API",
-      "example": "if (value instanceof ArrayBuffer) { ... }",
-      "notes": "Platform-specific, use instanceof directly"
-    },
-    {
       "name": "isHtmlElement / isUrlInstance / isUrlSearchParams",
       "libraries": [
         "sindresorhus/is"

--- a/helpers/type/isArrayBuffer.example.ts
+++ b/helpers/type/isArrayBuffer.example.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isArrayBuffer } from './isArrayBuffer';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'isArrayBuffer',
+  category: 'type',
+  examples: [
+    {
+      title: 'Detect an ArrayBuffer',
+      description: 'Returns true only for ArrayBuffer instances, not TypedArray views.',
+      code: `isArrayBuffer(new ArrayBuffer(8)) // => true
+isArrayBuffer(new Uint8Array(8))  // => false
+isArrayBuffer('hello')            // => false`,
+      assert: () => {
+        if (!isArrayBuffer(new ArrayBuffer(8))) throw new Error('ArrayBuffer(8) should return true');
+        if (isArrayBuffer(new Uint8Array(8))) throw new Error('Uint8Array should return false');
+        if (isArrayBuffer('hello')) throw new Error('"hello" should return false');
+      },
+    },
+    {
+      title: 'Filter ArrayBuffers from a mixed array',
+      description: 'Use as a predicate in .filter() to extract ArrayBuffer values.',
+      code: `const values = [new ArrayBuffer(4), 'text', new ArrayBuffer(8), 42];
+values.filter(isArrayBuffer)
+// => [ArrayBuffer(4), ArrayBuffer(8)]`,
+      assert: () => {
+        const values: unknown[] = [new ArrayBuffer(4), 'text', new ArrayBuffer(8), 42];
+        const result = values.filter(isArrayBuffer);
+        if (result.length !== 2) throw new Error(`Expected 2, got ${result.length}`);
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/type/isArrayBuffer.spec.ts
+++ b/helpers/type/isArrayBuffer.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { isArrayBuffer } from './isArrayBuffer';
+
+describe('isArrayBuffer — property-based', () => {
+  it('ArrayBuffer instances always return true', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 1024 }), (size) => {
+        expect(isArrayBuffer(new ArrayBuffer(size))).toBe(true);
+      }),
+    );
+  });
+
+  it('primitives never return true', () => {
+    fc.assert(
+      fc.property(fc.oneof(fc.string(), fc.integer(), fc.boolean()), (primitive) => {
+        expect(isArrayBuffer(primitive)).toBe(false);
+      }),
+    );
+  });
+});
+
+describe('isArrayBuffer — contract', () => {
+  it('new ArrayBuffer(0) → true', () => expect(isArrayBuffer(new ArrayBuffer(0))).toBe(true));
+  it('new ArrayBuffer(8) → true', () => expect(isArrayBuffer(new ArrayBuffer(8))).toBe(true));
+  it('new Uint8Array(8) → false', () => expect(isArrayBuffer(new Uint8Array(8))).toBe(false));
+  it('null → false', () => expect(isArrayBuffer(null)).toBe(false));
+  it('undefined → false', () => expect(isArrayBuffer(undefined)).toBe(false));
+  it('{} → false', () => expect(isArrayBuffer({})).toBe(false));
+  it('[] → false', () => expect(isArrayBuffer([])).toBe(false));
+});

--- a/helpers/type/isArrayBuffer.test.ts
+++ b/helpers/type/isArrayBuffer.test.ts
@@ -1,0 +1,32 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isArrayBuffer } from './isArrayBuffer';
+
+describe('isArrayBuffer', () => {
+  it('should return true for ArrayBuffer instances', () => {
+    expect(isArrayBuffer(new ArrayBuffer(0))).toBe(true);
+    expect(isArrayBuffer(new ArrayBuffer(8))).toBe(true);
+    expect(isArrayBuffer(new ArrayBuffer(1024))).toBe(true);
+  });
+
+  it('should return false for TypedArray views', () => {
+    expect(isArrayBuffer(new Uint8Array(8))).toBe(false);
+    expect(isArrayBuffer(new Int32Array(4))).toBe(false);
+    expect(isArrayBuffer(new Float64Array(2))).toBe(false);
+  });
+
+  it('should return false for other values', () => {
+    expect(isArrayBuffer(null)).toBe(false);
+    expect(isArrayBuffer(undefined)).toBe(false);
+    expect(isArrayBuffer('')).toBe(false);
+    expect(isArrayBuffer(42)).toBe(false);
+    expect(isArrayBuffer({})).toBe(false);
+    expect(isArrayBuffer([])).toBe(false);
+    expect(isArrayBuffer(new Blob())).toBe(false);
+  });
+});

--- a/helpers/type/isArrayBuffer.ts
+++ b/helpers/type/isArrayBuffer.ts
@@ -1,0 +1,23 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Checks if a value is an ArrayBuffer instance.
+ *
+ * Useful for filtering or type-narrowing in a functional pipeline:
+ * `values.filter(isArrayBuffer)`
+ *
+ * @param value - The value to check
+ * @returns True if value is an ArrayBuffer
+ * @example
+ * isArrayBuffer(new ArrayBuffer(8)) // => true
+ * isArrayBuffer(new Uint8Array(8))  // => false
+ * isArrayBuffer('hello')            // => false
+ * @since next
+ */
+export function isArrayBuffer(value: unknown): value is ArrayBuffer {
+  return value instanceof ArrayBuffer;
+}

--- a/helpers/type/isBlob.example.ts
+++ b/helpers/type/isBlob.example.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isBlob } from './isBlob';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'isBlob',
+  category: 'type',
+  examples: [
+    {
+      title: 'Detect a Blob',
+      description: 'Returns true only for Blob instances.',
+      code: `isBlob(new Blob(['hello'])) // => true
+isBlob(new Blob([], { type: 'application/json' })) // => true
+isBlob('hello')             // => false`,
+      assert: () => {
+        if (!isBlob(new Blob(['hello']))) throw new Error("Blob(['hello']) should return true");
+        if (isBlob('hello')) throw new Error('"hello" should return false');
+        if (isBlob(null)) throw new Error('null should return false');
+      },
+    },
+    {
+      title: 'Filter Blobs from a mixed array',
+      description: 'Use as a predicate in .filter() to extract Blob values.',
+      code: `const values = [new Blob(['a']), 'text', new Blob(['b']), 42];
+values.filter(isBlob)
+// => [Blob, Blob]`,
+      assert: () => {
+        const values: unknown[] = [new Blob(['a']), 'text', new Blob(['b']), 42];
+        const result = values.filter(isBlob);
+        if (result.length !== 2) throw new Error(`Expected 2, got ${result.length}`);
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/type/isBlob.spec.ts
+++ b/helpers/type/isBlob.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { isBlob } from './isBlob';
+
+describe('isBlob — property-based', () => {
+  it('Blob instances always return true', () => {
+    fc.assert(
+      fc.property(fc.string(), (content) => {
+        expect(isBlob(new Blob([content]))).toBe(true);
+      }),
+    );
+  });
+
+  it('primitives never return true', () => {
+    fc.assert(
+      fc.property(fc.oneof(fc.string(), fc.integer(), fc.boolean()), (primitive) => {
+        expect(isBlob(primitive)).toBe(false);
+      }),
+    );
+  });
+});
+
+describe('isBlob — contract', () => {
+  it('new Blob() → true', () => expect(isBlob(new Blob())).toBe(true));
+  it("new Blob(['hello']) → true", () => expect(isBlob(new Blob(['hello']))).toBe(true));
+  it('new ArrayBuffer(8) → false', () => expect(isBlob(new ArrayBuffer(8))).toBe(false));
+  it('null → false', () => expect(isBlob(null)).toBe(false));
+  it('undefined → false', () => expect(isBlob(undefined)).toBe(false));
+  it('{} → false', () => expect(isBlob({})).toBe(false));
+  it('"text" → false', () => expect(isBlob('text')).toBe(false));
+});

--- a/helpers/type/isBlob.test.ts
+++ b/helpers/type/isBlob.test.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isBlob } from './isBlob';
+
+describe('isBlob', () => {
+  it('should return true for Blob instances', () => {
+    expect(isBlob(new Blob())).toBe(true);
+    expect(isBlob(new Blob(['hello']))).toBe(true);
+    expect(isBlob(new Blob(['{}'], { type: 'application/json' }))).toBe(true);
+  });
+
+  it('should return false for non-Blob values', () => {
+    expect(isBlob(null)).toBe(false);
+    expect(isBlob(undefined)).toBe(false);
+    expect(isBlob('')).toBe(false);
+    expect(isBlob(42)).toBe(false);
+    expect(isBlob({})).toBe(false);
+    expect(isBlob([])).toBe(false);
+    expect(isBlob(new ArrayBuffer(8))).toBe(false);
+  });
+});

--- a/helpers/type/isBlob.ts
+++ b/helpers/type/isBlob.ts
@@ -1,0 +1,23 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Checks if a value is a Blob instance.
+ *
+ * Useful for filtering or type-narrowing in a functional pipeline:
+ * `values.filter(isBlob)`
+ *
+ * @param value - The value to check
+ * @returns True if value is a Blob
+ * @example
+ * isBlob(new Blob(['hello']))        // => true
+ * isBlob(new Blob([], { type: 'application/json' })) // => true
+ * isBlob('hello')                    // => false
+ * @since next
+ */
+export function isBlob(value: unknown): value is Blob {
+  return value instanceof Blob;
+}

--- a/helpers/type/isBlob.ts
+++ b/helpers/type/isBlob.ts
@@ -19,5 +19,5 @@
  * @since next
  */
 export function isBlob(value: unknown): value is Blob {
-  return value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }

--- a/helpers/type/isBuffer.example.ts
+++ b/helpers/type/isBuffer.example.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isBuffer } from './isBuffer';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'isBuffer',
+  category: 'type',
+  examples: [
+    {
+      title: 'Detect a Node.js Buffer',
+      description: 'Returns true only for Buffer instances. Uint8Array is not a Buffer.',
+      code: `isBuffer(Buffer.from('hello')) // => true
+isBuffer(new Uint8Array(8))    // => false
+isBuffer('hello')              // => false`,
+      assert: () => {
+        if (!isBuffer(Buffer.from('hello'))) throw new Error("Buffer.from('hello') should return true");
+        if (isBuffer(new Uint8Array(8))) throw new Error('Uint8Array should return false');
+        if (isBuffer('hello')) throw new Error('"hello" should return false');
+      },
+    },
+    {
+      title: 'Filter Buffers from a mixed array',
+      description: 'Use as a predicate in .filter() to extract Buffer values.',
+      code: `const values = [Buffer.from('a'), 'text', Buffer.alloc(4), 42];
+values.filter(isBuffer)
+// => [Buffer, Buffer]`,
+      assert: () => {
+        const values: unknown[] = [Buffer.from('a'), 'text', Buffer.alloc(4), 42];
+        const result = values.filter(isBuffer);
+        if (result.length !== 2) throw new Error(`Expected 2, got ${result.length}`);
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/type/isBuffer.spec.ts
+++ b/helpers/type/isBuffer.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { isBuffer } from './isBuffer';
+
+describe('isBuffer — property-based', () => {
+  it('Buffer.from(string) always returns true', () => {
+    fc.assert(
+      fc.property(fc.string(), (str) => {
+        expect(isBuffer(Buffer.from(str))).toBe(true);
+      }),
+    );
+  });
+
+  it('primitives never return true', () => {
+    fc.assert(
+      fc.property(fc.oneof(fc.string(), fc.integer(), fc.boolean()), (primitive) => {
+        expect(isBuffer(primitive)).toBe(false);
+      }),
+    );
+  });
+});
+
+describe('isBuffer — contract', () => {
+  it("Buffer.from('hello') → true", () => expect(isBuffer(Buffer.from('hello'))).toBe(true));
+  it('Buffer.alloc(0) → true', () => expect(isBuffer(Buffer.alloc(0))).toBe(true));
+  it('new Uint8Array(8) → false (Uint8Array is not Buffer)', () => expect(isBuffer(new Uint8Array(8))).toBe(false));
+  it('new ArrayBuffer(8) → false', () => expect(isBuffer(new ArrayBuffer(8))).toBe(false));
+  it('null → false', () => expect(isBuffer(null)).toBe(false));
+  it('undefined → false', () => expect(isBuffer(undefined)).toBe(false));
+  it('{} → false', () => expect(isBuffer({})).toBe(false));
+  it('"hello" → false', () => expect(isBuffer('hello')).toBe(false));
+});

--- a/helpers/type/isBuffer.test.ts
+++ b/helpers/type/isBuffer.test.ts
@@ -1,0 +1,33 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isBuffer } from './isBuffer';
+
+describe('isBuffer', () => {
+  it('should return true for Buffer instances', () => {
+    expect(isBuffer(Buffer.from('hello'))).toBe(true);
+    expect(isBuffer(Buffer.from([1, 2, 3]))).toBe(true);
+    expect(isBuffer(Buffer.alloc(8))).toBe(true);
+    expect(isBuffer(Buffer.alloc(0))).toBe(true);
+  });
+
+  it('should return false for Uint8Array (not a Buffer)', () => {
+    expect(isBuffer(new Uint8Array(8))).toBe(false);
+    expect(isBuffer(new Uint8Array([1, 2, 3]))).toBe(false);
+  });
+
+  it('should return false for other values', () => {
+    expect(isBuffer(null)).toBe(false);
+    expect(isBuffer(undefined)).toBe(false);
+    expect(isBuffer('')).toBe(false);
+    expect(isBuffer('hello')).toBe(false);
+    expect(isBuffer(42)).toBe(false);
+    expect(isBuffer({})).toBe(false);
+    expect(isBuffer([])).toBe(false);
+    expect(isBuffer(new ArrayBuffer(8))).toBe(false);
+  });
+});

--- a/helpers/type/isBuffer.ts
+++ b/helpers/type/isBuffer.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Checks if a value is a Node.js Buffer instance.
+ *
+ * `Buffer` extends `Uint8Array` and is specific to Node.js, Bun, and Deno.
+ * In browser-only environments where `Buffer` is not defined, this function
+ * always returns `false`.
+ *
+ * Useful for filtering or type-narrowing in a functional pipeline:
+ * `values.filter(isBuffer)`
+ *
+ * @param value - The value to check
+ * @returns True if value is a Buffer
+ * @example
+ * isBuffer(Buffer.from('hello')) // => true
+ * isBuffer(new Uint8Array(8))    // => false
+ * isBuffer('hello')              // => false
+ * @since next
+ */
+export function isBuffer(value: unknown): value is Buffer {
+  return typeof Buffer !== 'undefined' && value instanceof Buffer;
+}

--- a/helpers/type/isFormData.example.ts
+++ b/helpers/type/isFormData.example.ts
@@ -1,0 +1,45 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isFormData } from './isFormData';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'isFormData',
+  category: 'type',
+  examples: [
+    {
+      title: 'Detect a FormData',
+      description: 'Returns true only for FormData instances.',
+      code: `isFormData(new FormData()) // => true
+isFormData({})             // => false
+isFormData(null)           // => false`,
+      assert: () => {
+        if (!isFormData(new FormData())) throw new Error('FormData() should return true');
+        if (isFormData({})) throw new Error('{} should return false');
+        if (isFormData(null)) throw new Error('null should return false');
+      },
+    },
+    {
+      title: 'Filter FormData from a mixed array',
+      description: 'Use as a predicate in .filter() to extract FormData values.',
+      code: `const fd = new FormData();
+fd.append('name', 'Alice');
+const values = [fd, {}, new FormData(), 'text'];
+values.filter(isFormData)
+// => [FormData, FormData]`,
+      assert: () => {
+        const fd = new FormData();
+        fd.append('name', 'Alice');
+        const values: unknown[] = [fd, {}, new FormData(), 'text'];
+        const result = values.filter(isFormData);
+        if (result.length !== 2) throw new Error(`Expected 2, got ${result.length}`);
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/type/isFormData.spec.ts
+++ b/helpers/type/isFormData.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { isFormData } from './isFormData';
+
+describe('isFormData — property-based', () => {
+  it('primitives never return true', () => {
+    fc.assert(
+      fc.property(fc.oneof(fc.string(), fc.integer(), fc.boolean()), (primitive) => {
+        expect(isFormData(primitive)).toBe(false);
+      }),
+    );
+  });
+});
+
+describe('isFormData — contract', () => {
+  it('new FormData() → true', () => expect(isFormData(new FormData())).toBe(true));
+  it('FormData with entries → true', () => {
+    const fd = new FormData();
+    fd.append('k', 'v');
+    expect(isFormData(fd)).toBe(true);
+  });
+  it('null → false', () => expect(isFormData(null)).toBe(false));
+  it('undefined → false', () => expect(isFormData(undefined)).toBe(false));
+  it('{} → false', () => expect(isFormData({})).toBe(false));
+  it('new URLSearchParams() → false', () => expect(isFormData(new URLSearchParams())).toBe(false));
+  it('new Blob() → false', () => expect(isFormData(new Blob())).toBe(false));
+});

--- a/helpers/type/isFormData.test.ts
+++ b/helpers/type/isFormData.test.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isFormData } from './isFormData';
+
+describe('isFormData', () => {
+  it('should return true for FormData instances', () => {
+    expect(isFormData(new FormData())).toBe(true);
+
+    const fd = new FormData();
+    fd.append('key', 'value');
+    expect(isFormData(fd)).toBe(true);
+  });
+
+  it('should return false for non-FormData values', () => {
+    expect(isFormData(null)).toBe(false);
+    expect(isFormData(undefined)).toBe(false);
+    expect(isFormData('')).toBe(false);
+    expect(isFormData(42)).toBe(false);
+    expect(isFormData({})).toBe(false);
+    expect(isFormData([])).toBe(false);
+    expect(isFormData(new Blob())).toBe(false);
+    expect(isFormData(new URLSearchParams())).toBe(false);
+  });
+});

--- a/helpers/type/isFormData.ts
+++ b/helpers/type/isFormData.ts
@@ -19,5 +19,5 @@
  * @since next
  */
 export function isFormData(value: unknown): value is FormData {
-  return value instanceof FormData;
+  return typeof FormData !== 'undefined' && value instanceof FormData;
 }

--- a/helpers/type/isFormData.ts
+++ b/helpers/type/isFormData.ts
@@ -1,0 +1,23 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Checks if a value is a FormData instance.
+ *
+ * Useful for filtering or type-narrowing in a functional pipeline:
+ * `values.filter(isFormData)`
+ *
+ * @param value - The value to check
+ * @returns True if value is a FormData
+ * @example
+ * isFormData(new FormData()) // => true
+ * isFormData({})             // => false
+ * isFormData(null)           // => false
+ * @since next
+ */
+export function isFormData(value: unknown): value is FormData {
+  return value instanceof FormData;
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "coherency:category": "tsx scripts/coherency/category/index.ts",
     "coherency:dependencies": "tsx scripts/coherency/dependencies/index.ts",
     "coherency:sizes": "tsx scripts/coherency/sizes/index.ts",
+    "coherency:jsdoc-since": "tsx scripts/coherency/jsdoc-since/index.ts",
     "version:patch": "tsx scripts/version/version-manager.ts patch",
     "version:minor": "tsx scripts/version/version-manager.ts minor",
     "version:major": "tsx scripts/version/version-manager.ts major",

--- a/package.json
+++ b/package.json
@@ -92,5 +92,10 @@
   "engines": {
     "node": ">=24.0.0",
     "browser": "ES2022+"
+  },
+  "pnpm": {
+    "overrides": {
+      "postcss": ">=8.5.10"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss: '>=8.5.10'
+
 importers:
 
   .:
@@ -1607,8 +1610,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-ms@9.3.0:
@@ -3290,7 +3293,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.9:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -3504,7 +3507,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.10
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/scripts/build/build-website-metadata.ts
+++ b/scripts/build/build-website-metadata.ts
@@ -143,6 +143,11 @@ function serializeType(type: unknown): string {
     const target = serializeType(t.target);
     return `${op} ${target}`;
   }
+  if (t.type === 'predicate') {
+    const name = t.name as string;
+    if (t.targetType) return `${name} is ${serializeType(t.targetType)}`;
+    return name;
+  }
   return String(t.name || t.type || 'unknown');
 }
 

--- a/scripts/build/build-website-metadata.ts
+++ b/scripts/build/build-website-metadata.ts
@@ -72,6 +72,7 @@ interface WebsiteFunction {
   readonly signatures: readonly WebsiteSignature[];
   readonly examples: readonly WebsiteExample[];
   readonly sourceFile: string;
+  readonly typeDefinition?: string;
   readonly relatedTypes?: readonly WebsiteRelatedType[];
 }
 
@@ -273,7 +274,7 @@ function processMember(child: DeclarationReflection): WebsiteFunction | undefine
     })),
     sourceFile: fileName,
     ...(typeDefinition ? { typeDefinition } : {}),
-  } as WebsiteFunction & { typeDefinition?: string };
+  };
 }
 
 function readDependencyLicense(packageName: string): WebsiteDependency {
@@ -423,7 +424,7 @@ export async function buildWebsiteMetadata(validCategories: string[]): Promise<v
         list.push({
           name: fn.name,
           description: fn.description,
-          typeDefinition: (fn as WebsiteFunction & { typeDefinition?: string }).typeDefinition ?? fn.name,
+          typeDefinition: fn.typeDefinition ?? fn.name,
         });
         companionTypesMap.set(companionFnName, list);
       }

--- a/scripts/build/build-website-metadata.ts
+++ b/scripts/build/build-website-metadata.ts
@@ -58,6 +58,12 @@ interface WebsiteExample {
   readonly code: string;
 }
 
+interface WebsiteRelatedType {
+  readonly name: string;
+  readonly description: string;
+  readonly typeDefinition: string;
+}
+
 interface WebsiteFunction {
   readonly name: string;
   readonly kind: 'function' | 'type' | 'interface' | 'variable';
@@ -66,6 +72,7 @@ interface WebsiteFunction {
   readonly signatures: readonly WebsiteSignature[];
   readonly examples: readonly WebsiteExample[];
   readonly sourceFile: string;
+  readonly relatedTypes?: readonly WebsiteRelatedType[];
 }
 
 interface WebsiteDependency {
@@ -129,6 +136,11 @@ function serializeType(type: unknown): string {
   if (t.type === 'union') return (t.types as unknown[]).map(serializeType).join(' | ');
   if (t.type === 'intersection') return (t.types as unknown[]).map(serializeType).join(' & ');
   if (t.type === 'literal') return JSON.stringify(t.value);
+  if (t.type === 'namedTupleMember') {
+    const memberName = t.name as string;
+    const isOptional = (t.isOptional as boolean | undefined) ? '?' : '';
+    return `${memberName}${isOptional}: ${serializeType(t.element)}`;
+  }
   if (t.type === 'tuple') {
     const elems = (t.elements as unknown[]) ?? [];
     return `[${elems.map(serializeType).join(', ')}]`;
@@ -224,6 +236,23 @@ function processMember(child: DeclarationReflection): WebsiteFunction | undefine
   const since = extractTagText(comment?.blockTags as CommentTag[] | undefined, '@since') ?? 'unknown';
   const examples = extractExamples(comment?.blockTags as CommentTag[] | undefined);
 
+  // For type aliases: build the `type Name<T> = ...` definition string
+  let typeDefinition: string | undefined;
+  if (kind === 'type' && (child as unknown as Record<string, unknown>).type) {
+    const rawType = (child as unknown as Record<string, unknown>).type;
+    const typeStr = serializeType(rawType);
+    const typeParams = child.typeParameters
+      ?.map((tp: TypeParameterReflection) => {
+        let s = tp.name;
+        if (tp.type) s += ` extends ${serializeType(tp.type)}`;
+        if (tp.default) s += ` = ${serializeType(tp.default)}`;
+        return s;
+      })
+      .join(', ');
+    const generics = typeParams ? `<${typeParams}>` : '';
+    typeDefinition = `type ${child.name}${generics} = ${typeStr}`;
+  }
+
   // Source file name
   const sourceFile = child.sources?.[0]?.fileName
     ?? `${child.name}.ts`;
@@ -243,7 +272,8 @@ function processMember(child: DeclarationReflection): WebsiteFunction | undefine
       code,
     })),
     sourceFile: fileName,
-  };
+    ...(typeDefinition ? { typeDefinition } : {}),
+  } as WebsiteFunction & { typeDefinition?: string };
 }
 
 function readDependencyLicense(packageName: string): WebsiteDependency {
@@ -367,13 +397,50 @@ export async function buildWebsiteMetadata(validCategories: string[]): Promise<v
 
     // Merge .example.ts examples into functions (richer than JSDoc @example)
     const exampleMap = await loadExampleFiles(category);
-    const enrichedFunctions = functions.map(fn => {
-      const fileExamples = exampleMap.get(fn.name);
-      if (fileExamples?.length) {
-        return { ...fn, examples: fileExamples };
+
+    // --- Detect 1:1 companion types (type that shares sourceFile with exactly one function) ---
+    // These will be embedded in their companion function's page instead of having a standalone page.
+    const funcNamesBySourceFile = new Map<string, string[]>();
+    for (const fn of functions) {
+      if (fn.kind === 'function') {
+        const list = funcNamesBySourceFile.get(fn.sourceFile) ?? [];
+        list.push(fn.name);
+        funcNamesBySourceFile.set(fn.sourceFile, list);
       }
-      return fn;
-    });
+    }
+
+    // companion types indexed by their companion function name
+    const companionTypesMap = new Map<string, WebsiteRelatedType[]>();
+    const companionTypeNames = new Set<string>();
+    for (const fn of functions) {
+      if (fn.kind !== 'type') continue;
+      const sharedWithFunctions = funcNamesBySourceFile.get(fn.sourceFile) ?? [];
+      if (sharedWithFunctions.length === 1) {
+        // 1:1 companion — embed in the function
+        companionTypeNames.add(fn.name);
+        const companionFnName = sharedWithFunctions[0];
+        const list = companionTypesMap.get(companionFnName) ?? [];
+        list.push({
+          name: fn.name,
+          description: fn.description,
+          typeDefinition: (fn as WebsiteFunction & { typeDefinition?: string }).typeDefinition ?? fn.name,
+        });
+        companionTypesMap.set(companionFnName, list);
+      }
+      // 1:N companions keep their standalone page — no action needed
+    }
+
+    const enrichedFunctions = functions
+      .filter(fn => !companionTypeNames.has(fn.name)) // exclude 1:1 companion types
+      .map(fn => {
+        const fileExamples = exampleMap.get(fn.name);
+        const relatedTypes = companionTypesMap.get(fn.name) ?? [];
+        return {
+          ...fn,
+          ...(fileExamples?.length ? { examples: fileExamples } : {}),
+          ...(relatedTypes.length ? { relatedTypes } : {}),
+        };
+      });
 
     enrichedFunctions.sort((a, b) => a.name.localeCompare(b.name));
 

--- a/scripts/coherency/index.ts
+++ b/scripts/coherency/index.ts
@@ -9,7 +9,7 @@
 // Simple index that runs all coherency tests by calling their individual scripts
 import { execSync } from 'node:child_process';
 
-const tests = ['bundle', 'version', 'category', 'dependencies', 'sizes'];
+const tests = ['bundle', 'version', 'category', 'dependencies', 'sizes', 'jsdoc-since'];
 
 async function runAllTests() {
   console.log("🔍 Running coherency tests in parallel...\n");

--- a/scripts/coherency/jsdoc-since/helper.ts
+++ b/scripts/coherency/jsdoc-since/helper.ts
@@ -8,12 +8,12 @@ import fs from 'fs-extra';
 import path from 'node:path';
 
 /** File suffixes that are not helper implementations */
-const SKIP_SUFFIXES = ['.test.ts', '.spec.ts', '.bench.ts', '.example.ts'];
+export const SKIP_SUFFIXES = ['.test.ts', '.spec.ts', '.bench.ts', '.example.ts'];
 
 /** Filenames that are never helper implementations */
-const SKIP_FILENAMES = new Set(['index.ts']);
+export const SKIP_FILENAMES = new Set(['index.ts']);
 
-function isHelperSourceFile(filename: string): boolean {
+export function isHelperSourceFile(filename: string): boolean {
   if (SKIP_FILENAMES.has(filename)) return false;
   for (const suffix of SKIP_SUFFIXES) {
     if (filename.endsWith(suffix)) return false;

--- a/scripts/coherency/jsdoc-since/helper.ts
+++ b/scripts/coherency/jsdoc-since/helper.ts
@@ -49,7 +49,9 @@ export async function checkJsDocSince(): Promise<void> {
       const content = await fs.readFile(filePath, 'utf-8');
       const relative = path.relative(process.cwd(), filePath);
 
-      if (!/@since\s+\S+/.test(content)) {
+      const jsDocBlocks = [...content.matchAll(/\/\*\*[\s\S]*?\*\//g)];
+      const hasSince = jsDocBlocks.some(([block]) => /@since\s+\S+/.test(block));
+      if (!hasSince) {
         errors.push(`  ❌ Missing @since tag: ${relative}`);
       } else {
         console.log(`  ✅ ${relative}`);

--- a/scripts/coherency/jsdoc-since/helper.ts
+++ b/scripts/coherency/jsdoc-since/helper.ts
@@ -1,0 +1,65 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import fs from 'fs-extra';
+import path from 'node:path';
+
+/** File suffixes that are not helper implementations */
+const SKIP_SUFFIXES = ['.test.ts', '.spec.ts', '.bench.ts', '.example.ts'];
+
+/** Filenames that are never helper implementations */
+const SKIP_FILENAMES = new Set(['index.ts']);
+
+function isHelperSourceFile(filename: string): boolean {
+  if (SKIP_FILENAMES.has(filename)) return false;
+  for (const suffix of SKIP_SUFFIXES) {
+    if (filename.endsWith(suffix)) return false;
+  }
+  return filename.endsWith('.ts');
+}
+
+/**
+ * Check that every helper source file contains at least one `@since` JSDoc tag.
+ * The expected value for new helpers is `@since next` (see CONTRIBUTING.md).
+ */
+export async function checkJsDocSince(): Promise<void> {
+  console.log('  📋 Checking @since JSDoc tags in helper source files...');
+
+  const helpersDir = path.resolve(process.cwd(), 'helpers');
+  if (!await fs.pathExists(helpersDir)) {
+    throw new Error('helpers/ directory not found.');
+  }
+
+  const errors: string[] = [];
+
+  const categories = await fs.readdir(helpersDir);
+  for (const category of categories) {
+    const categoryPath = path.join(helpersDir, category);
+    const stat = await fs.stat(categoryPath);
+    if (!stat.isDirectory()) continue;
+
+    const files = await fs.readdir(categoryPath);
+    for (const filename of files) {
+      if (!isHelperSourceFile(filename)) continue;
+
+      const filePath = path.join(categoryPath, filename);
+      const content = await fs.readFile(filePath, 'utf-8');
+      const relative = path.relative(process.cwd(), filePath);
+
+      if (!/@since\s+\S+/.test(content)) {
+        errors.push(`  ❌ Missing @since tag: ${relative}`);
+      } else {
+        console.log(`  ✅ ${relative}`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`JSDoc @since check failed:\n${errors.join('\n')}`);
+  }
+
+  console.log('  ✅ All helper source files have valid @since tags');
+}

--- a/scripts/coherency/jsdoc-since/index.ts
+++ b/scripts/coherency/jsdoc-since/index.ts
@@ -10,8 +10,8 @@
  * JSDoc @since coherency test
  *
  * Rules enforced:
- *   - Every helper source file must contain a @since JSDoc tag.
- *   - The expected value for new helpers is `@since next` (see CONTRIBUTING.md).
+ *   - Every helper source file must contain a @since JSDoc tag inside a JSDoc block.
+ *   - Convention: use `@since next` for new helpers (injected at stable release time).
  */
 
 import { checkJsDocSince } from './helper';
@@ -19,7 +19,7 @@ import { checkJsDocSince } from './helper';
 async function runJsDocSinceTest() {
   try {
     console.log('🧪 JSDoc @since:');
-    console.log('   Ensures every helper has a @since tag and new files use @since next');
+    console.log('   Ensures every helper source file contains a @since tag in a JSDoc block');
 
     await checkJsDocSince();
 

--- a/scripts/coherency/jsdoc-since/index.ts
+++ b/scripts/coherency/jsdoc-since/index.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * JSDoc @since coherency test
+ *
+ * Rules enforced:
+ *   - Every helper source file must contain a @since JSDoc tag.
+ *   - New files (vs origin/main) must use `@since next`.
+ *   - A real version on a new file is flagged as a likely copy-paste mistake.
+ *   - Existing files must not carry `@since next`.
+ */
+
+import { checkJsDocSince } from './helper';
+
+async function runJsDocSinceTest() {
+  try {
+    console.log('🧪 JSDoc @since:');
+    console.log('   Ensures every helper has a @since tag and new files use @since next');
+
+    await checkJsDocSince();
+
+    console.log('✅ JSDoc @since passed');
+    process.exit(0);
+  } catch (error) {
+    console.error('❌ JSDoc @since failed:', error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}
+
+if (import.meta.url.includes(process.argv[1]) || import.meta.url.includes('jsdoc-since')) {
+  runJsDocSinceTest().catch(console.error);
+}

--- a/scripts/coherency/jsdoc-since/index.ts
+++ b/scripts/coherency/jsdoc-since/index.ts
@@ -11,9 +11,7 @@
  *
  * Rules enforced:
  *   - Every helper source file must contain a @since JSDoc tag.
- *   - New files (vs origin/main) must use `@since next`.
- *   - A real version on a new file is flagged as a likely copy-paste mistake.
- *   - Existing files must not carry `@since next`.
+ *   - The expected value for new helpers is `@since next` (see CONTRIBUTING.md).
  */
 
 import { checkJsDocSince } from './helper';

--- a/scripts/version/inject-since.ts
+++ b/scripts/version/inject-since.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import fs from 'fs-extra';
+import path from 'node:path';
+
+/** File suffixes that are not helper implementations */
+const SKIP_SUFFIXES = ['.test.ts', '.spec.ts', '.bench.ts', '.example.ts'];
+
+/** Filenames that are never helper implementations */
+const SKIP_FILENAMES = new Set(['index.ts']);
+
+function isHelperSourceFile(filename: string): boolean {
+  if (SKIP_FILENAMES.has(filename)) return false;
+  for (const suffix of SKIP_SUFFIXES) {
+    if (filename.endsWith(suffix)) return false;
+  }
+  return filename.endsWith('.ts');
+}
+
+/**
+ * Returns true when the version string has a prerelease suffix
+ * (e.g. `2.0.0-alpha.19`, `2.1.0-beta.0`, `3.0.0-rc.1`).
+ */
+export function isPrerelease(version: string): boolean {
+  return version.includes('-');
+}
+
+/**
+ * Inject the real version into every helper source file that carries `@since next`.
+ *
+ * Only called on stable releases — prerelease builds keep `@since next` so that
+ * the tag retains its semantic meaning ("next stable release").
+ *
+ * @param version - The new stable version string (e.g. `2.1.0`).
+ * @param dryRun  - When true, print what would change but write nothing.
+ * @returns Absolute paths of files that were (or would be) modified.
+ */
+export async function injectSinceVersion(
+  version: string,
+  dryRun = false
+): Promise<string[]> {
+  if (isPrerelease(version)) {
+    throw new Error(
+      `injectSinceVersion must only be called for stable releases. Got: ${version}`
+    );
+  }
+
+  console.log(`\n🔖 Step 3b: Injecting @since ${version} into helper files`);
+
+  const helpersDir = path.resolve(process.cwd(), 'helpers');
+  if (!await fs.pathExists(helpersDir)) {
+    throw new Error('helpers/ directory not found.');
+  }
+
+  const modified: string[] = [];
+
+  const categories = await fs.readdir(helpersDir);
+  for (const category of categories) {
+    const categoryPath = path.join(helpersDir, category);
+    const stat = await fs.stat(categoryPath);
+    if (!stat.isDirectory()) continue;
+
+    const files = await fs.readdir(categoryPath);
+    for (const filename of files) {
+      if (!isHelperSourceFile(filename)) continue;
+
+      const filePath = path.join(categoryPath, filename);
+      const content = await fs.readFile(filePath, 'utf-8');
+
+      if (!content.includes('@since next')) continue;
+
+      const updated = content.replaceAll('@since next', `@since ${version}`);
+
+      if (dryRun) {
+        console.log(`  [DRY RUN] Would replace @since next → @since ${version} in ${path.relative(process.cwd(), filePath)}`);
+      } else {
+        await fs.writeFile(filePath, updated, 'utf-8');
+        console.log(`  ✅ ${path.relative(process.cwd(), filePath)}`);
+      }
+
+      modified.push(filePath);
+    }
+  }
+
+  if (modified.length === 0) {
+    console.log('  ℹ️  No files with @since next found — nothing to inject');
+  } else {
+    console.log(`✅ @since injection done (${modified.length} file(s) updated)`);
+  }
+
+  return modified;
+}

--- a/scripts/version/inject-since.ts
+++ b/scripts/version/inject-since.ts
@@ -8,20 +8,7 @@
 
 import fs from 'fs-extra';
 import path from 'node:path';
-
-/** File suffixes that are not helper implementations */
-const SKIP_SUFFIXES = ['.test.ts', '.spec.ts', '.bench.ts', '.example.ts'];
-
-/** Filenames that are never helper implementations */
-const SKIP_FILENAMES = new Set(['index.ts']);
-
-function isHelperSourceFile(filename: string): boolean {
-  if (SKIP_FILENAMES.has(filename)) return false;
-  for (const suffix of SKIP_SUFFIXES) {
-    if (filename.endsWith(suffix)) return false;
-  }
-  return filename.endsWith('.ts');
-}
+import { isHelperSourceFile } from '../coherency/jsdoc-since/helper';
 
 /**
  * Returns true when the version string has a prerelease suffix

--- a/scripts/version/release.ts
+++ b/scripts/version/release.ts
@@ -76,12 +76,13 @@ export async function performRelease(options: ReleaseOptions): Promise<void> {
       const result = await updateAllPackageVersions(updateOptions);
       ({ newVersion } = result);
     } else {
-      // Simulate version calculation for dry run
-      const fs = await import('fs-extra');
-      const packageJson = await fs.readJson('./package.json');
-      const typeInfo = options.autoCalculate ? 'auto-calculated' : options.versionType;
-      console.log(`[DRY RUN] Would update version from ${packageJson.version} (${typeInfo})`);
-      newVersion = 'x.x.x-dry-run';
+      // Compute the real new version in dry-run mode (no files written)
+      // so that stableRelease is correctly derived even in dry-run
+      const updateOptions = options.autoCalculate
+        ? { autoCalculate: true, dryRun: true }
+        : { dryRun: true, versionType: options.versionType };
+      const result = await updateAllPackageVersions(updateOptions);
+      ({ newVersion } = result);
     }
 
     const releaseTag = `v${newVersion}`;

--- a/scripts/version/release.ts
+++ b/scripts/version/release.ts
@@ -9,6 +9,7 @@
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { updateAllPackageVersions } from './version-manager';
+import { injectSinceVersion, isPrerelease } from './inject-since';
 import { createVersionCommitAndTag, getCurrentBranch, isWorkingDirectoryClean } from './git-utils';
 import type { VersionType } from './commit-analyzer';
 
@@ -84,6 +85,18 @@ export async function performRelease(options: ReleaseOptions): Promise<void> {
     }
 
     const releaseTag = `v${newVersion}`;
+    const stableRelease = !isPrerelease(newVersion);
+
+    // Step 3b: Inject @since next → @since <version> (stable releases only)
+    if (stableRelease) {
+      if (!options.dryRun) {
+        await injectSinceVersion(newVersion);
+      } else {
+        console.log(`[DRY RUN] Would inject @since ${newVersion} into helper files with @since next`);
+      }
+    } else {
+      console.log(`\n🔖 Step 3b: Skipping @since injection — prerelease (${newVersion}), keeping @since next`);
+    }
 
     // Step 4: Generate changelog
     console.log('\n📋 Step 4: Generating changelog');
@@ -121,7 +134,12 @@ export async function performRelease(options: ReleaseOptions): Promise<void> {
     console.log('\n📝 Step 7: Creating version commit');
     if (!options.dryRun) {
       await createVersionCommitAndTag({
-        files: ['package.json', 'build/', 'CHANGELOG.md'],
+        files: [
+          'package.json',
+          'build/',
+          'CHANGELOG.md',
+          ...(stableRelease ? ['helpers/'] : []),
+        ],
         message: `chore: release v${newVersion}`,
         pushBranch: targetBranch
       });


### PR DESCRIPTION
## Description

Improves the website metadata build pipeline to correctly handle TypeScript type aliases that are co-located with their companion function.

**Problem:** Types like `Result` (in `tryit.ts`), `Falsy` (in `isFalsy.ts`), and `Primitive` (in `isPrimitive.ts`) were getting their own standalone documentation pages, even though they are purely internal return/companion types of a single function. This made the docs sidebar noisy and the type pages had no useful standalone context.

**Solution:**
- **1:1 companion types** (a type that shares its source file with exactly one function) are now embedded as a "Related Types" section inside their companion function's page, and no longer generate a standalone page.
- **1:N shared types** (e.g. `SortFn`, `DateTruncUnit`, `WeekDay`) keep their standalone page since they are referenced by multiple functions.

Additionally, two bugs in `serializeType` were fixed:
- **`namedTupleMember`** support: named tuple labels (e.g. `[error: undefined, value: T]`) were previously collapsed to just the member name, losing the type information.
- **`predicate`** support: type guard return types (e.g. `value is string`) were serialized as just `"value"` instead of the full predicate.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Related Issues

N/A

## How Has This Been Tested?

- Verified `Result`, `Falsy`, and `Primitive` no longer appear as standalone pages after `pnpm build` + doc generation.
- Verified `Result` appears in the "Related Types" section of `tryit.md`.
- Verified `SortFn`, `DateTruncUnit`, `WeekDay` still have their own standalone pages (1:N case).
- Verified `isString`, `isNumber`, `isValidDate`, `isArray` etc. now show correct type predicate signatures (`value is string`, `value is number`, …).
- Verified `Result<T>` type definition now correctly serializes as `[error: undefined, value: T] | [error: Error, value: undefined]`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed locally
- [x] My commits follow the conventional commit format
