### PR TITLE
For alpha 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,6 +260,10 @@ jobs:
           name: release-build
           path: build/
 
+      - name: Inject @since version (stable releases only)
+        if: needs.build-and-verify.outputs.is-prerelease == 'false'
+        run: pnpm exec tsx scripts/version/inject-since.ts "${{ needs.build-and-verify.outputs.new-version }}"
+
       - name: Get version
         id: version
         run: |
@@ -272,6 +276,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json
+          if [ "${{ needs.build-and-verify.outputs.is-prerelease }}" = "false" ]; then
+            git add helpers/
+          fi
           git commit -m "chore(release): 🔧 bump version to ${{ steps.version.outputs.new-version }}" || echo "No changes to commit"
 
       - name: Push version commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,7 +262,8 @@ jobs:
 
       - name: Inject @since version (stable releases only)
         if: needs.build-and-verify.outputs.is-prerelease == 'false'
-        run: pnpm exec tsx scripts/version/inject-since.ts "${{ needs.build-and-verify.outputs.new-version }}"
+        run: pnpm exec tsx scripts/version/inject-since.ts "${{
+          needs.build-and-verify.outputs.new-version }}"
 
       - name: Get version
         id: version
@@ -407,6 +408,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ publish ]
     if: ${{ !inputs.dry-run }}
+    continue-on-error: true
     concurrency:
       group: trigger-website-docs-${{ needs.publish.outputs.new-version }}
       cancel-in-progress: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PUSHINATOR_ID }}
+          client-id: ${{ vars.PUSHINATOR_ID }}
           private-key: ${{ secrets.PUSHINATOR_KEY }}
 
       - name: Checkout code
@@ -227,7 +227,7 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PUSHINATOR_ID }}
+          client-id: ${{ vars.PUSHINATOR_ID }}
           private-key: ${{ secrets.PUSHINATOR_KEY }}
 
       - name: Checkout code
@@ -351,37 +351,12 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
 
-      - name: Get Trigganator token
-        id: trigganator
-        if: ${{ !inputs.dry-run }}
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ vars.TRIGGANATOR_ID }}
-          private-key: ${{ secrets.TRIGGANATOR_KEY }}
-          owner: helpers4
-          repositories: website
-
-      - name: Trigger documentation update
-        id: trigger_docs
-        if: ${{ !inputs.dry-run }}
-        continue-on-error: true
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          token: ${{ steps.trigganator.outputs.token }}
-          repository: helpers4/website
-          event-type: typescript-release
-          client-payload: "{\"version\": \"${{ steps.version.outputs.new-version }}\"}"
-
       - name: Release summary
         run: |
           echo "✅ Release completed successfully!"
           echo "📦 Version: ${{ steps.version.outputs.new-version }}"
           echo "🏷️  NPM tag: ${{ steps.version.outputs.npm-tag }}"
-          if [ "${{ steps.trigger_docs.outcome }}" = "success" ]; then
-            echo "📚 Documentation update triggered"
-          else
-            echo "⚠️  Documentation update trigger failed (non-blocking)"
-          fi
+          echo "📚 Website docs trigger runs in dedicated post-publish job"
 
       - name: Dry-run summary
         if: ${{ inputs.dry-run }}
@@ -418,3 +393,41 @@ jobs:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
           STRYKER_DASHBOARD_VERSION: v${{ needs.publish.outputs.new-version }}
         run: pnpm mutation
+
+  # Step 10: Trigger website docs refresh
+  # Runs after publish and in parallel with mutation-dashboard-report.
+  trigger-website-docs:
+    runs-on: ubuntu-latest
+    needs: [ publish ]
+    if: ${{ !inputs.dry-run }}
+    concurrency:
+      group: trigger-website-docs-${{ needs.publish.outputs.new-version }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Get Trigganator token
+        id: trigganator
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.TRIGGANATOR_ID }}
+          private-key: ${{ secrets.TRIGGANATOR_KEY }}
+          owner: helpers4
+          repositories: website
+
+      - name: Trigger website docs update
+        id: trigger_docs
+        continue-on-error: true
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ steps.trigganator.outputs.token }}
+          repository: helpers4/website
+          event-type: typescript-release
+          client-payload: "{\"version\": \"${{ needs.publish.outputs.new-version }}\"}"
+
+      - name: Trigger summary
+        run: |
+          if [ "${{ steps.trigger_docs.outcome }}" = "success" ]; then
+            echo "✅ Website docs trigger dispatched for v${{ needs.publish.outputs.new-version }}"
+          else
+            echo "⚠️  Website docs trigger failed (non-blocking) for v${{ needs.publish.outputs.new-version }}"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,11 @@ jobs:
 
           echo "✅ Version bumped to $NEW_VERSION"
 
+      - name: Inject @since version (stable releases only)
+        if: steps.version.outputs.is-prerelease == 'false'
+        run: pnpm exec tsx scripts/version/inject-since.ts "${{
+          steps.version.outputs.new-version }}"
+
       - name: Build project
         run: pnpm run build
 
@@ -213,6 +218,14 @@ jobs:
         with:
           name: release-build
           path: build/
+          retention-days: 1
+
+      - name: Upload modified helpers (stable releases only)
+        if: steps.version.outputs.is-prerelease == 'false'
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-helpers
+          path: helpers/
           retention-days: 1
 
   # Step 8: Publish release
@@ -260,10 +273,12 @@ jobs:
           name: release-build
           path: build/
 
-      - name: Inject @since version (stable releases only)
+      - name: Download modified helpers (stable releases only)
         if: needs.build-and-verify.outputs.is-prerelease == 'false'
-        run: pnpm exec tsx scripts/version/inject-since.ts "${{
-          needs.build-and-verify.outputs.new-version }}"
+        uses: actions/download-artifact@v8
+        with:
+          name: release-helpers
+          path: helpers/
 
       - name: Get version
         id: version

--- a/helpers/number/formatSize.example.ts
+++ b/helpers/number/formatSize.example.ts
@@ -1,0 +1,31 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { formatSize } from './formatSize';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'formatSize',
+  category: 'number',
+  examples: [
+    {
+      title: 'Format bytes to human-readable size',
+      description: 'Converts a raw byte count to a human-readable string using binary prefixes.',
+      code: `formatSize(0)             // '0.0B'
+formatSize(512)           // '512.0B'
+formatSize(1024)          // '1.0KB'
+formatSize(1_048_576)     // '1.0MB'
+formatSize(1_073_741_824) // '1.0GB'`,
+      assert: () => {
+        if (formatSize(0) !== '0.0B') throw new Error(`Unexpected: ${formatSize(0)}`);
+        if (formatSize(1024) !== '1.0KB') throw new Error(`Unexpected: ${formatSize(1024)}`);
+        if (formatSize(1_048_576) !== '1.0MB') throw new Error(`Unexpected: ${formatSize(1_048_576)}`);
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/number/formatSize.spec.ts
+++ b/helpers/number/formatSize.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { formatSize } from './formatSize';
+
+describe('formatSize — property-based', () => {
+  it('always returns a string ending with a known unit', () => {
+    fc.assert(
+      fc.property(fc.nat(10 ** 12), (bytes) => {
+        const result = formatSize(bytes);
+        expect(result).toMatch(/^[\d.]+[BKMGT]B?$/);
+      }),
+    );
+  });
+
+  it('result for values < 1024 always ends with "B" (no prefix)', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 1023 }), (bytes) => {
+        expect(formatSize(bytes)).toMatch(/B$/);
+        expect(formatSize(bytes)).not.toMatch(/KB|MB|GB|TB/);
+      }),
+    );
+  });
+
+  it('result for values >= 1024 and < 1_048_576 ends with "KB"', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1024, max: 1_048_575 }), (bytes) => {
+        expect(formatSize(bytes)).toMatch(/KB$/);
+      }),
+    );
+  });
+
+  it('always contains a decimal point', () => {
+    fc.assert(
+      fc.property(fc.nat(10 ** 12), (bytes) => {
+        expect(formatSize(bytes)).toContain('.');
+      }),
+    );
+  });
+
+  it('larger inputs within the same unit range produce a >= numeric value', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1024, max: 1_048_575 }),
+        fc.integer({ min: 1024, max: 1_048_575 }),
+        (a, b) => {
+          fc.pre(a !== b);
+          const smaller = Math.min(a, b);
+          const larger = Math.max(a, b);
+          const smallerFormatted = formatSize(smaller);
+          const largerFormatted = formatSize(larger);
+          expect(smallerFormatted).toMatch(/KB$/);
+          expect(largerFormatted).toMatch(/KB$/);
+          expect(parseFloat(largerFormatted)).toBeGreaterThanOrEqual(parseFloat(smallerFormatted));
+        },
+      ),
+    );
+  });
+});
+
+describe('formatSize — contract', () => {
+  it('0 bytes → "0.0B"', () => expect(formatSize(0)).toBe('0.0B'));
+  it('exactly 1 KB', () => expect(formatSize(1024)).toBe('1.0KB'));
+  it('exactly 1 MB', () => expect(formatSize(1024 * 1024)).toBe('1.0MB'));
+  it('exactly 1 GB', () => expect(formatSize(1024 * 1024 * 1024)).toBe('1.0GB'));
+});

--- a/helpers/number/formatSize.test.ts
+++ b/helpers/number/formatSize.test.ts
@@ -1,0 +1,43 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatSize } from './formatSize';
+
+describe('formatSize — bytes (B)', () => {
+  it('0 bytes', () => expect(formatSize(0)).toBe('0.0B'));
+  it('1 byte', () => expect(formatSize(1)).toBe('1.0B'));
+  it('512 bytes', () => expect(formatSize(512)).toBe('512.0B'));
+  it('1023 bytes (just under KB)', () => expect(formatSize(1023)).toBe('1023.0B'));
+});
+
+describe('formatSize — kilobytes (KB)', () => {
+  it('1024 bytes = 1.0KB', () => expect(formatSize(1024)).toBe('1.0KB'));
+  it('1536 bytes = 1.5KB', () => expect(formatSize(1536)).toBe('1.5KB'));
+  it('2048 bytes = 2.0KB', () => expect(formatSize(2048)).toBe('2.0KB'));
+});
+
+describe('formatSize — megabytes (MB)', () => {
+  it('1_048_576 bytes = 1.0MB', () => expect(formatSize(1_048_576)).toBe('1.0MB'));
+  it('2_097_152 bytes = 2.0MB', () => expect(formatSize(2_097_152)).toBe('2.0MB'));
+});
+
+describe('formatSize — gigabytes (GB)', () => {
+  it('1_073_741_824 bytes = 1.0GB', () => expect(formatSize(1_073_741_824)).toBe('1.0GB'));
+});
+
+describe('formatSize — terabytes (TB)', () => {
+  it('1_099_511_627_776 bytes = 1.0TB', () => expect(formatSize(1_099_511_627_776)).toBe('1.0TB'));
+  it('large value stays in TB', () => expect(formatSize(5 * 1_099_511_627_776)).toBe('5.0TB'));
+});
+
+describe('formatSize — decimal formatting', () => {
+  it('always has exactly one decimal place', () => {
+    for (const input of [0, 1, 1024, 1_048_576]) {
+      expect(formatSize(input)).toMatch(/\.\d[A-Z]/);
+    }
+  });
+});

--- a/helpers/number/formatSize.ts
+++ b/helpers/number/formatSize.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/** Size units in ascending order. */
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB'] as const;
+
+/**
+ * Format a byte count into a human-readable string with the appropriate unit.
+ *
+ * Each unit is 1024 of the previous (binary prefix). The result is formatted
+ * with one decimal place.
+ *
+ * @param bytes - A non-negative integer representing a byte count.
+ * @returns A human-readable string such as `'0.0B'`, `'1.5KB'`, `'3.2MB'`.
+ * @example
+ * formatSize(0)               // '0.0B'
+ * formatSize(512)             // '512.0B'
+ * formatSize(1024)            // '1.0KB'
+ * formatSize(1536)            // '1.5KB'
+ * formatSize(1_048_576)       // '1.0MB'
+ * formatSize(1_073_741_824)   // '1.0GB'
+ * @since next
+ */
+export function formatSize(bytes: number): string {
+  let size = bytes;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < UNITS.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+
+  return `${size.toFixed(1)}${UNITS[unitIndex]}`;
+}

--- a/helpers/url/parsePackageRepository.example.ts
+++ b/helpers/url/parsePackageRepository.example.ts
@@ -1,0 +1,56 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { parsePackageRepository } from './parsePackageRepository';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'parsePackageRepository',
+  category: 'url',
+  examples: [
+    {
+      title: 'Parse the npm canonical object form',
+      description: 'Parses the full object form written by npm publish.',
+      code: `parsePackageRepository({ type: 'git', url: 'git+https://github.com/helpers4/typescript.git' })
+// => { type: 'git', host: 'github', slug: 'helpers4/typescript',
+//      owner: 'helpers4', repo: 'typescript', gistId: undefined, directory: undefined }`,
+      assert: () => {
+        const result = parsePackageRepository({
+          type: 'git',
+          url: 'git+https://github.com/helpers4/typescript.git',
+        });
+        if (result?.host !== 'github') throw new Error(`Unexpected host: ${result?.host}`);
+        if (result?.slug !== 'helpers4/typescript') throw new Error(`Unexpected slug: ${result?.slug}`);
+      },
+    },
+    {
+      title: 'Parse npm shorthand forms',
+      description: 'npm accepts "owner/repo", "github:owner/repo", "gitlab:owner/repo" etc. as shorthand.',
+      code: `parsePackageRepository('helpers4/typescript')
+// => { host: 'github', slug: 'helpers4/typescript', owner: 'helpers4', repo: 'typescript', ... }
+
+parsePackageRepository('gitlab:myorg/myproject')
+// => { host: 'gitlab', slug: 'myorg/myproject', owner: 'myorg', repo: 'myproject', ... }
+
+parsePackageRepository('gist:11081aaa281')
+// => { host: 'gist', gistId: '11081aaa281', slug: undefined, owner: undefined, ... }`,
+      assert: () => {
+        const gh = parsePackageRepository('helpers4/typescript');
+        if (gh?.host !== 'github' || gh?.slug !== 'helpers4/typescript')
+          throw new Error('Bare shorthand failed');
+
+        const gl = parsePackageRepository('gitlab:myorg/myproject');
+        if (gl?.host !== 'gitlab') throw new Error('GitLab shorthand failed');
+
+        const gist = parsePackageRepository('gist:11081aaa281');
+        if (gist?.gistId !== '11081aaa281' || gist?.slug !== undefined)
+          throw new Error('Gist shorthand failed');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/url/parsePackageRepository.spec.ts
+++ b/helpers/url/parsePackageRepository.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { parsePackageRepository } from './parsePackageRepository';
+
+const KNOWN_HOSTS = ['github', 'gitlab', 'bitbucket'] as const;
+
+const arbitrarySlug = fc.tuple(
+  fc.stringMatching(/^[\w][\w.-]{0,19}$/),
+  fc.stringMatching(/^[\w][\w.-]{0,19}$/),
+).map(([owner, repo]) => `${owner}/${repo}`);
+
+describe('parsePackageRepository — property-based', () => {
+  it('null / undefined always returns undefined', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(null, undefined), (value) => {
+        expect(parsePackageRepository(value)).toBeUndefined();
+      }),
+    );
+  });
+
+  it('arrays always return undefined', () => {
+    fc.assert(
+      fc.property(fc.array(fc.string()), (arr) => {
+        expect(parsePackageRepository(arr)).toBeUndefined();
+      }),
+    );
+  });
+
+  it('"github/gitlab/bitbucket:owner/repo" shorthand always resolves to the correct host', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...KNOWN_HOSTS),
+        arbitrarySlug,
+        (platform, slug) => {
+          const result = parsePackageRepository(`${platform}:${slug}`);
+          expect(result?.host).toBe(platform);
+          expect(result?.slug).toBe(slug);
+        },
+      ),
+    );
+  });
+
+  it('"gist:<id>" shorthand always returns host=gist with gistId set', () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[\w-]{4,20}$/),
+        (id) => {
+          const result = parsePackageRepository(`gist:${id}`);
+          expect(result?.host).toBe('gist');
+          expect(result?.gistId).toBe(id);
+          expect(result?.slug).toBeUndefined();
+        },
+      ),
+    );
+  });
+
+  it('bare "owner/repo" shorthand always returns host=github', () => {
+    fc.assert(
+      fc.property(arbitrarySlug, (slug) => {
+        const result = parsePackageRepository(slug);
+        expect(result?.host).toBe('github');
+        expect(result?.slug).toBe(slug);
+      }),
+    );
+  });
+
+  it('when slug is defined, it equals owner + "/" + repo', () => {
+    fc.assert(
+      fc.property(arbitrarySlug, (slug) => {
+        const result = parsePackageRepository(slug);
+        if (result?.slug !== undefined) {
+          expect(result.slug).toBe(`${result.owner}/${result.repo}`);
+        }
+      }),
+    );
+  });
+
+  it('gist results always have gistId and no slug/owner/repo', () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[\w-]{4,20}$/),
+        (id) => {
+          const result = parsePackageRepository(`gist:${id}`);
+          expect(result?.gistId).toBeDefined();
+          expect(result?.slug).toBeUndefined();
+          expect(result?.owner).toBeUndefined();
+          expect(result?.repo).toBeUndefined();
+        },
+      ),
+    );
+  });
+
+  it('object form with type preserves the type field', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom('git', 'svn', 'hg'),
+        arbitrarySlug,
+        (type, slug) => {
+          const [owner, repo] = slug.split('/');
+          const result = parsePackageRepository({
+            type,
+            url: `https://github.com/${owner}/${repo}`,
+          });
+          expect(result?.type).toBe(type);
+        },
+      ),
+    );
+  });
+
+  it('object form with directory preserves the directory field', () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[\w/-]{1,40}$/),
+        (dir) => {
+          const result = parsePackageRepository({
+            url: 'https://github.com/owner/repo',
+            directory: dir,
+          });
+          expect(result?.directory).toBe(dir);
+        },
+      ),
+    );
+  });
+});
+
+describe('parsePackageRepository — contract', () => {
+  it('npm canonical object form', () => {
+    const result = parsePackageRepository({
+      type: 'git',
+      url: 'git+https://github.com/npm/cli.git',
+    });
+    expect(result).toMatchObject({ host: 'github', owner: 'npm', repo: 'cli' });
+  });
+
+  it('bare slug → github host', () =>
+    expect(parsePackageRepository('npm/example')?.host).toBe('github'));
+
+  it('gist shorthand → host=gist, slug=undefined', () => {
+    const r = parsePackageRepository('gist:abc123');
+    expect(r?.host).toBe('gist');
+    expect(r?.slug).toBeUndefined();
+  });
+
+  it('SCP SSH URL → correct slug', () => {
+    const r = parsePackageRepository({ url: 'git@github.com:helpers4/typescript.git' });
+    expect(r?.slug).toBe('helpers4/typescript');
+  });
+
+  it('codeberg.org URL → host is codeberg.org (unknown domain)', () => {
+    const r = parsePackageRepository({ url: 'https://codeberg.org/myorg/myrepo' });
+    expect(r?.host).toBe('codeberg.org');
+  });
+});

--- a/helpers/url/parsePackageRepository.test.ts
+++ b/helpers/url/parsePackageRepository.test.ts
@@ -1,0 +1,192 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parsePackageRepository } from './parsePackageRepository';
+
+describe('parsePackageRepository — null / undefined / invalid', () => {
+  it('null → undefined', () => expect(parsePackageRepository(null)).toBeUndefined());
+  it('undefined → undefined', () => expect(parsePackageRepository(undefined)).toBeUndefined());
+  it('number → undefined', () => expect(parsePackageRepository(42)).toBeUndefined());
+  it('boolean → undefined', () => expect(parsePackageRepository(true)).toBeUndefined());
+  it('array → undefined', () => expect(parsePackageRepository(['github:a/b'])).toBeUndefined());
+  it('empty string → undefined', () => expect(parsePackageRepository('')).toBeUndefined());
+  it('unrecognised string → undefined', () =>
+    expect(parsePackageRepository('not-a-repo-field')).toBeUndefined());
+  it('object without url → undefined', () =>
+    expect(parsePackageRepository({ type: 'git' })).toBeUndefined());
+  it('object with non-string url → undefined', () =>
+    expect(parsePackageRepository({ type: 'git', url: 42 })).toBeUndefined());
+});
+
+describe('parsePackageRepository — shorthand string forms', () => {
+  it('bare "owner/repo" → github', () => {
+    const result = parsePackageRepository('helpers4/typescript');
+    expect(result).toEqual({
+      type: 'git',
+      host: 'github',
+      slug: 'helpers4/typescript',
+      owner: 'helpers4',
+      repo: 'typescript',
+      gistId: undefined,
+      directory: undefined,
+    });
+  });
+
+  it('"github:owner/repo"', () => {
+    const result = parsePackageRepository('github:helpers4/typescript');
+    expect(result).toMatchObject({ host: 'github', slug: 'helpers4/typescript', owner: 'helpers4', repo: 'typescript' });
+  });
+
+  it('"gitlab:owner/repo"', () => {
+    const result = parsePackageRepository('gitlab:myorg/myproject');
+    expect(result).toMatchObject({ host: 'gitlab', slug: 'myorg/myproject', owner: 'myorg', repo: 'myproject' });
+  });
+
+  it('"bitbucket:owner/repo"', () => {
+    const result = parsePackageRepository('bitbucket:myorg/myrepo');
+    expect(result).toMatchObject({ host: 'bitbucket', slug: 'myorg/myrepo', owner: 'myorg', repo: 'myrepo' });
+  });
+
+  it('"gist:<id>"', () => {
+    const result = parsePackageRepository('gist:11081aaa281');
+    expect(result).toEqual({
+      type: 'git',
+      host: 'gist',
+      slug: undefined,
+      owner: undefined,
+      repo: undefined,
+      gistId: '11081aaa281',
+      directory: undefined,
+    });
+  });
+
+  it('shorthand string → directory always undefined', () => {
+    expect(parsePackageRepository('helpers4/typescript')?.directory).toBeUndefined();
+    expect(parsePackageRepository('github:helpers4/typescript')?.directory).toBeUndefined();
+    expect(parsePackageRepository('gist:abc123')?.directory).toBeUndefined();
+  });
+
+  it('shorthand string → type always "git"', () => {
+    expect(parsePackageRepository('helpers4/typescript')?.type).toBe('git');
+    expect(parsePackageRepository('github:helpers4/typescript')?.type).toBe('git');
+  });
+});
+
+describe('parsePackageRepository — object form, URL variants', () => {
+  it('git+https URL (npm canonical form)', () => {
+    const result = parsePackageRepository({
+      type: 'git',
+      url: 'git+https://github.com/helpers4/typescript.git',
+    });
+    expect(result).toEqual({
+      type: 'git',
+      host: 'github',
+      slug: 'helpers4/typescript',
+      owner: 'helpers4',
+      repo: 'typescript',
+      gistId: undefined,
+      directory: undefined,
+    });
+  });
+
+  it('plain https URL', () => {
+    const result = parsePackageRepository({ url: 'https://github.com/helpers4/typescript' });
+    expect(result).toMatchObject({ host: 'github', slug: 'helpers4/typescript' });
+  });
+
+  it('git:// URL', () => {
+    const result = parsePackageRepository({ url: 'git://github.com/npm/cli.git#v1.0.27' });
+    expect(result).toMatchObject({ host: 'github', slug: 'npm/cli' });
+  });
+
+  it('SCP-style SSH: git@github.com:owner/repo.git', () => {
+    const result = parsePackageRepository({ url: 'git@github.com:helpers4/typescript.git' });
+    expect(result).toMatchObject({ host: 'github', slug: 'helpers4/typescript' });
+  });
+
+  it('SCP-style SSH with unknown host → falls back to raw domain', () => {
+    const result = parsePackageRepository({ url: 'git@codeberg.org:myorg/myrepo.git' });
+    expect(result).toMatchObject({ host: 'codeberg.org', slug: 'myorg/myrepo' });
+  });
+
+  it('git+ssh URL: git+ssh://git@github.com/owner/repo.git', () => {
+    const result = parsePackageRepository({
+      url: 'git+ssh://git@github.com/helpers4/typescript.git',
+    });
+    expect(result).toMatchObject({ host: 'github', slug: 'helpers4/typescript' });
+  });
+
+  it('GitLab URL', () => {
+    const result = parsePackageRepository({ url: 'https://gitlab.com/myorg/myproject.git' });
+    expect(result).toMatchObject({ host: 'gitlab', slug: 'myorg/myproject' });
+  });
+
+  it('Bitbucket URL', () => {
+    const result = parsePackageRepository({ url: 'https://bitbucket.org/myorg/myrepo.git' });
+    expect(result).toMatchObject({ host: 'bitbucket', slug: 'myorg/myrepo' });
+  });
+
+  it('unknown host → falls back to raw domain', () => {
+    const result = parsePackageRepository({ url: 'https://codeberg.org/myorg/myrepo.git' });
+    expect(result).toMatchObject({ host: 'codeberg.org', slug: 'myorg/myrepo' });
+  });
+
+  it('preserves custom type', () => {
+    const result = parsePackageRepository({
+      type: 'svn',
+      url: 'https://github.com/helpers4/typescript',
+    });
+    expect(result?.type).toBe('svn');
+  });
+
+  it('extracts directory field', () => {
+    const result = parsePackageRepository({
+      type: 'git',
+      url: 'git+https://github.com/npm/cli.git',
+      directory: 'workspaces/libnpmpublish',
+    });
+    expect(result?.directory).toBe('workspaces/libnpmpublish');
+  });
+
+  it('object without type → defaults to "git"', () => {
+    const result = parsePackageRepository({ url: 'https://github.com/a/b' });
+    expect(result?.type).toBe('git');
+  });
+
+  it('object without directory → undefined', () => {
+    const result = parsePackageRepository({ url: 'https://github.com/a/b' });
+    expect(result?.directory).toBeUndefined();
+  });
+
+  it('URL with semver fragment', () => {
+    const result = parsePackageRepository({
+      url: 'git+ssh://git@github.com/npm/cli.git#semver:^5.0',
+    });
+    expect(result).toMatchObject({ host: 'github', slug: 'npm/cli' });
+  });
+});
+
+describe('parsePackageRepository — slug / owner / repo / gistId consistency', () => {
+  it('when slug is set, slug === owner + "/" + repo', () => {
+    const result = parsePackageRepository('helpers4/typescript');
+    expect(result?.slug).toBe(`${result?.owner}/${result?.repo}`);
+  });
+
+  it('for gist shorthand, slug is undefined and gistId is set', () => {
+    const result = parsePackageRepository('gist:abc123');
+    expect(result?.slug).toBeUndefined();
+    expect(result?.owner).toBeUndefined();
+    expect(result?.repo).toBeUndefined();
+    expect(result?.gistId).toBe('abc123');
+  });
+
+  it('for non-gist results, gistId is always undefined', () => {
+    expect(parsePackageRepository('helpers4/typescript')?.gistId).toBeUndefined();
+    expect(parsePackageRepository('github:a/b')?.gistId).toBeUndefined();
+    expect(parsePackageRepository({ url: 'https://github.com/a/b' })?.gistId).toBeUndefined();
+  });
+});

--- a/helpers/url/parsePackageRepository.ts
+++ b/helpers/url/parsePackageRepository.ts
@@ -1,0 +1,170 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Structured representation of a parsed `repository` field from `package.json`.
+ *
+ * @since next
+ */
+export interface PackageRepository {
+  /**
+   * VCS type (e.g. `'git'`, `'svn'`).
+   * Defaults to `'git'` when using shorthand string forms.
+   */
+  readonly type: string;
+  /**
+   * Hosting platform.
+   * Well-known values: `'github'`, `'gitlab'`, `'bitbucket'`, `'gist'`.
+   * Falls back to the raw domain (e.g. `'codeberg.org'`) for unknown hosts.
+   */
+  readonly host: 'github' | 'gitlab' | 'bitbucket' | 'gist' | (string & {});
+  /**
+   * `<owner>/<repo>` slug.
+   * `undefined` for gist shorthands (`gist:<id>`) and unrecognised URL shapes.
+   */
+  readonly slug: string | undefined;
+  /**
+   * Repository owner or organisation.
+   * `undefined` for gist shorthands.
+   */
+  readonly owner: string | undefined;
+  /**
+   * Repository name.
+   * `undefined` for gist shorthands.
+   */
+  readonly repo: string | undefined;
+  /**
+   * Gist identifier — only set when using the `gist:<id>` shorthand form.
+   */
+  readonly gistId: string | undefined;
+  /**
+   * Monorepo sub-directory from the `directory` field of the object form.
+   * `undefined` when using shorthand string forms or when no `directory` is specified.
+   */
+  readonly directory: string | undefined;
+}
+
+/** Maps known GitHub/GitLab/Bitbucket domains to their platform name. */
+const DOMAIN_TO_HOST: Record<string, string> = {
+  'github.com': 'github',
+  'gitlab.com': 'gitlab',
+  'bitbucket.org': 'bitbucket',
+  'gist.github.com': 'gist',
+};
+
+/** SCP-style SSH URL: `git@github.com:owner/repo.git` */
+const RE_SSH_SCP = /^git@([\w.-]+):([\w.-]+\/[\w.-]+?)(?:\.git)?(?:[#?].*)?$/;
+
+/**
+ * URL-form remote: `git+https://…`, `https://…`, `git://…`, `git+ssh://git@…`
+ * Captures: [1] domain, [2] owner/repo path
+ */
+const RE_URL =
+  /^(?:git\+(?:https?|ssh)|https?|git):\/\/(?:[^@/]+@)?([\w.-]+)\/([\w.-]+\/[\w.-]+?)(?:\.git)?(?:[#?].*)?$/;
+
+function makeOwnerRepoResult(
+  type: string,
+  host: string,
+  rawPath: string,
+  directory: string | undefined,
+): PackageRepository {
+  const slashIdx = rawPath.indexOf('/');
+  const owner = rawPath.slice(0, slashIdx);
+  const repo = rawPath.slice(slashIdx + 1);
+  return { type, host, slug: `${owner}/${repo}`, owner, repo, gistId: undefined, directory };
+}
+
+function parseRawUrl(
+  raw: string,
+  type: string,
+  directory: string | undefined,
+): PackageRepository | undefined {
+  // Shorthand prefix: "github:owner/repo", "gitlab:owner/repo", "bitbucket:owner/repo"
+  const shorthandMatch = /^(github|gitlab|bitbucket):([\w.-]+\/[\w.-]+)$/.exec(raw);
+  if (shorthandMatch) {
+    const host = shorthandMatch[1] as 'github' | 'gitlab' | 'bitbucket';
+    const slug = shorthandMatch[2];
+    const slashIdx = slug.indexOf('/');
+    const owner = slug.slice(0, slashIdx);
+    const repo = slug.slice(slashIdx + 1);
+    return { type, host, slug, owner, repo, gistId: undefined, directory };
+  }
+
+  // Gist shorthand: "gist:<id>"
+  const gistMatch = /^gist:([\w-]+)$/.exec(raw);
+  if (gistMatch) {
+    return { type, host: 'gist', slug: undefined, owner: undefined, repo: undefined, gistId: gistMatch[1], directory };
+  }
+
+  // Bare GitHub shorthand: "owner/repo" (no colon prefix, no protocol)
+  const bareMatch = /^([\w.-]+)\/([\w.-]+)$/.exec(raw);
+  if (bareMatch) {
+    const owner = bareMatch[1];
+    const repo = bareMatch[2];
+    return { type, host: 'github', slug: `${owner}/${repo}`, owner, repo, gistId: undefined, directory };
+  }
+
+  // SCP-style SSH: git@github.com:owner/repo.git
+  const sshMatch = RE_SSH_SCP.exec(raw);
+  if (sshMatch) {
+    const host = DOMAIN_TO_HOST[sshMatch[1]] ?? sshMatch[1];
+    return makeOwnerRepoResult(type, host, sshMatch[2], directory);
+  }
+
+  // URL-form: https://, git+https://, git://, git+ssh://
+  const urlMatch = RE_URL.exec(raw);
+  if (urlMatch) {
+    const host = DOMAIN_TO_HOST[urlMatch[1]] ?? urlMatch[1];
+    return makeOwnerRepoResult(type, host, urlMatch[2], directory);
+  }
+
+  return undefined;
+}
+
+/**
+ * Parse the `repository` field from `package.json` into a structured object.
+ *
+ * Supports all npm-specified formats:
+ * - **Object form**: `{ "type": "git", "url": "...", "directory": "..." }`
+ * - **GitHub shorthand**: `"owner/repo"` or `"github:owner/repo"`
+ * - **Platform shorthands**: `"gitlab:owner/repo"`, `"bitbucket:owner/repo"`
+ * - **Gist shorthand**: `"gist:<id>"`
+ * - **URL forms**: `git+https://`, `https://`, `git://`, `git@` SSH, `git+ssh://`
+ *
+ * Returns `undefined` for `null`, `undefined`, arrays, or values that cannot
+ * be matched to any recognised format.
+ *
+ * @param repository - The `repository` field value from `package.json`.
+ * @returns A parsed {@link PackageRepository} object, or `undefined` if the
+ *   input cannot be parsed.
+ * @example
+ * parsePackageRepository({ type: 'git', url: 'git+https://github.com/helpers4/typescript.git' })
+ * // => { type: 'git', host: 'github', slug: 'helpers4/typescript', owner: 'helpers4',
+ * //      repo: 'typescript', gistId: undefined, directory: undefined }
+ * @example
+ * parsePackageRepository('github:helpers4/typescript')
+ * // => { type: 'git', host: 'github', slug: 'helpers4/typescript', owner: 'helpers4',
+ * //      repo: 'typescript', gistId: undefined, directory: undefined }
+ * @since next
+ */
+export function parsePackageRepository(repository: unknown): PackageRepository | undefined {
+  if (repository === null || repository === undefined) return undefined;
+
+  if (typeof repository === 'string') {
+    return parseRawUrl(repository, 'git', undefined);
+  }
+
+  if (typeof repository === 'object' && !Array.isArray(repository)) {
+    const obj = repository as Record<string, unknown>;
+    const rawUrl = obj['url'];
+    if (typeof rawUrl !== 'string') return undefined;
+    const type = typeof obj['type'] === 'string' ? (obj['type'] as string) : 'git';
+    const directory = typeof obj['directory'] === 'string' ? (obj['directory'] as string) : undefined;
+    return parseRawUrl(rawUrl, type, directory);
+  }
+
+  return undefined;
+}

--- a/helpers/url/parsePackageRepository.ts
+++ b/helpers/url/parsePackageRepository.ts
@@ -52,7 +52,6 @@ const DOMAIN_TO_HOST: Record<string, string> = {
   'github.com': 'github',
   'gitlab.com': 'gitlab',
   'bitbucket.org': 'bitbucket',
-  'gist.github.com': 'gist',
 };
 
 /** SCP-style SSH URL: `git@github.com:owner/repo.git` */

--- a/helpers/version/isPrerelease.example.ts
+++ b/helpers/version/isPrerelease.example.ts
@@ -1,0 +1,48 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isPrerelease } from './isPrerelease';
+import { parse } from './parse';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'isPrerelease',
+  category: 'version',
+  examples: [
+    {
+      title: 'Detect a prerelease version',
+      description: 'Returns true for any version string that contains a prerelease suffix.',
+      code: `isPrerelease('2.0.0-alpha.1') // true
+isPrerelease('1.0.0-rc.0')   // true`,
+      assert: () => {
+        if (!isPrerelease('2.0.0-alpha.1')) throw new Error('Expected true for alpha');
+        if (!isPrerelease('1.0.0-rc.0')) throw new Error('Expected true for rc');
+      },
+    },
+    {
+      title: 'Stable versions return false',
+      description: 'Returns false when the version has no prerelease suffix.',
+      code: `isPrerelease('1.0.0') // false
+isPrerelease('2.1.3') // false`,
+      assert: () => {
+        if (isPrerelease('1.0.0')) throw new Error('Expected false for stable');
+        if (isPrerelease('2.1.3')) throw new Error('Expected false for stable');
+      },
+    },
+    {
+      title: 'Accept a ParsedVersion object',
+      description: 'Works with the result of parse() — checks the prerelease array instead of string matching.',
+      code: `isPrerelease(parse('2.0.0-alpha.1')) // true
+isPrerelease(parse('1.0.0'))         // false`,
+      assert: () => {
+        if (!isPrerelease(parse('2.0.0-alpha.1'))) throw new Error('Expected true');
+        if (isPrerelease(parse('1.0.0'))) throw new Error('Expected false');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/version/isPrerelease.spec.ts
+++ b/helpers/version/isPrerelease.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { parse } from './parse';
+import { isPrerelease } from './isPrerelease';
+
+const stableVersion = fc
+  .tuple(fc.nat(99), fc.nat(99), fc.nat(99))
+  .map(([major, minor, patch]) => `${major}.${minor}.${patch}`);
+
+const prereleaseLabel = fc.constantFrom('alpha', 'beta', 'rc', 'next', 'canary');
+
+const prereleaseVersion = fc
+  .tuple(fc.nat(99), fc.nat(99), fc.nat(99), prereleaseLabel, fc.nat(20))
+  .map(([major, minor, patch, label, n]) => `${major}.${minor}.${patch}-${label}.${n}`);
+
+describe('isPrerelease — property-based (string)', () => {
+  it('stable versions always return false', () => {
+    fc.assert(
+      fc.property(stableVersion, (v) => {
+        expect(isPrerelease(v)).toBe(false);
+      }),
+    );
+  });
+
+  it('prerelease versions always return true', () => {
+    fc.assert(
+      fc.property(prereleaseVersion, (v) => {
+        expect(isPrerelease(v)).toBe(true);
+      }),
+    );
+  });
+});
+
+describe('isPrerelease — property-based (ParsedVersion)', () => {
+  it('string and ParsedVersion forms always agree', () => {
+    fc.assert(
+      fc.property(fc.oneof(stableVersion, prereleaseVersion), (v) => {
+        expect(isPrerelease(parse(v))).toBe(isPrerelease(v));
+      }),
+    );
+  });
+
+  it('ParsedVersion with empty prerelease array always returns false', () => {
+    fc.assert(
+      fc.property(
+        fc.tuple(fc.nat(99), fc.nat(99), fc.nat(99)),
+        ([major, minor, patch]) => {
+          expect(isPrerelease({ major, minor, patch, prerelease: [], build: [] })).toBe(false);
+        },
+      ),
+    );
+  });
+
+  it('ParsedVersion with non-empty prerelease array always returns true', () => {
+    fc.assert(
+      fc.property(
+        fc.tuple(fc.nat(99), fc.nat(99), fc.nat(99), fc.array(fc.string(), { minLength: 1 })),
+        ([major, minor, patch, prerelease]) => {
+          expect(isPrerelease({ major, minor, patch, prerelease, build: [] })).toBe(true);
+        },
+      ),
+    );
+  });
+});
+
+describe('isPrerelease — contract', () => {
+  it('return type is always boolean', () => {
+    expect(typeof isPrerelease('1.0.0')).toBe('boolean');
+    expect(typeof isPrerelease('1.0.0-alpha.1')).toBe('boolean');
+    expect(typeof isPrerelease(parse('1.0.0'))).toBe('boolean');
+  });
+  it('undefined → undefined', () => expect(isPrerelease(undefined)).toBeUndefined());
+  it('null → null', () => expect(isPrerelease(null)).toBeNull());
+});

--- a/helpers/version/isPrerelease.test.ts
+++ b/helpers/version/isPrerelease.test.ts
@@ -1,0 +1,40 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isPrerelease } from './isPrerelease';
+import { parse } from './parse';
+
+describe('isPrerelease — string input', () => {
+  it('alpha prerelease → true', () => expect(isPrerelease('2.0.0-alpha.1')).toBe(true));
+  it('beta prerelease → true', () => expect(isPrerelease('1.0.0-beta.0')).toBe(true));
+  it('rc prerelease → true', () => expect(isPrerelease('3.0.0-rc.2')).toBe(true));
+  it('arbitrary prerelease label → true', () => expect(isPrerelease('1.0.0-next')).toBe(true));
+  it('stable 1.0.0 → false', () => expect(isPrerelease('1.0.0')).toBe(false));
+  it('stable 2.1.3 → false', () => expect(isPrerelease('2.1.3')).toBe(false));
+  it('stable 0.0.1 → false', () => expect(isPrerelease('0.0.1')).toBe(false));
+  it('v-prefixed stable → false', () => expect(isPrerelease('v1.0.0')).toBe(false));
+  it('v-prefixed prerelease → true', () => expect(isPrerelease('v1.0.0-alpha.3')).toBe(true));
+  it('stable with build metadata containing dash → false', () => expect(isPrerelease('1.0.0+build-123')).toBe(false));
+  it('stable with build metadata → false', () => expect(isPrerelease('2.0.0+build.1')).toBe(false));
+});
+
+describe('isPrerelease — ParsedVersion input', () => {
+  it('parse(alpha) → true', () => expect(isPrerelease(parse('2.0.0-alpha.1'))).toBe(true));
+  it('parse(beta) → true', () => expect(isPrerelease(parse('1.0.0-beta.0'))).toBe(true));
+  it('parse(rc) → true', () => expect(isPrerelease(parse('3.0.0-rc.2'))).toBe(true));
+  it('parse(stable) → false', () => expect(isPrerelease(parse('1.0.0'))).toBe(false));
+  it('parse(stable with build) → false', () => expect(isPrerelease(parse('2.0.0+build.1'))).toBe(false));
+  it('direct object with non-empty prerelease → true', () =>
+    expect(isPrerelease({ major: 1, minor: 0, patch: 0, prerelease: ['alpha', '1'], build: [] })).toBe(true));
+  it('direct object with empty prerelease → false', () =>
+    expect(isPrerelease({ major: 1, minor: 0, patch: 0, prerelease: [], build: [] })).toBe(false));
+});
+
+describe('isPrerelease — null / undefined passthrough', () => {
+  it('undefined → undefined', () => expect(isPrerelease(undefined)).toBeUndefined());
+  it('null → null', () => expect(isPrerelease(null)).toBeNull());
+});

--- a/helpers/version/isPrerelease.ts
+++ b/helpers/version/isPrerelease.ts
@@ -1,0 +1,40 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import type { ParsedVersion } from './parse';
+
+/**
+ * Returns `true` when the version string has a prerelease suffix
+ * (i.e. contains a `-` after the core `MAJOR.MINOR.PATCH`).
+ *
+ * @param version - A semantic version string (e.g. `'2.0.0-alpha.1'`, `'1.0.0'`).
+ * @returns `true` if the version is a prerelease, `false` otherwise.
+ * @example
+ * isPrerelease('2.0.0-alpha.1') // true
+ * isPrerelease('1.0.0-rc.0')   // true
+ * isPrerelease('1.0.0')        // false
+ * isPrerelease('2.1.0')        // false
+ * @since next
+ */
+export function isPrerelease(version: string): boolean;
+/**
+ * Returns `true` when the parsed version has at least one prerelease identifier.
+ *
+ * @param version - A {@link ParsedVersion} object (as returned by {@link parse}).
+ * @returns `true` if `version.prerelease` is non-empty, `false` otherwise.
+ * @example
+ * isPrerelease(parse('2.0.0-alpha.1')) // true
+ * isPrerelease(parse('1.0.0'))         // false
+ * @since next
+ */
+export function isPrerelease(version: ParsedVersion): boolean;
+export function isPrerelease(version: undefined): undefined;
+export function isPrerelease(version: null): null;
+export function isPrerelease(version: string | ParsedVersion | undefined | null): boolean | undefined | null {
+  if (version === undefined || version === null) return version;
+  if (typeof version === 'string') return version.split('+')[0].includes('-');
+  return version.prerelease.length > 0;
+}

--- a/helpers/version/stringify.example.ts
+++ b/helpers/version/stringify.example.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { parse } from './parse';
+import { stringify } from './stringify';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'stringify',
+  category: 'version',
+  examples: [
+    {
+      title: 'Reconstruct a stable version',
+      description: 'Converts a ParsedVersion object back to a version string.',
+      code: `stringify({ major: 1, minor: 2, patch: 3, prerelease: [], build: [] })
+// => '1.2.3'`,
+      assert: () => {
+        const result = stringify({ major: 1, minor: 2, patch: 3, prerelease: [], build: [] });
+        if (result !== '1.2.3') throw new Error(`Unexpected: ${result}`);
+      },
+    },
+    {
+      title: 'Round-trip with parse',
+      description: 'stringify(parse(v)) returns the original version string (without leading v).',
+      code: `stringify(parse('2.0.0-alpha.1'))
+// => '2.0.0-alpha.1'
+
+stringify(parse('1.0.0-beta+exp.sha.5114f85'))
+// => '1.0.0-beta+exp.sha.5114f85'`,
+      assert: () => {
+        if (stringify(parse('2.0.0-alpha.1')) !== '2.0.0-alpha.1') throw new Error('Round-trip failed');
+        if (stringify(parse('1.0.0-beta+exp.sha.5114f85')) !== '1.0.0-beta+exp.sha.5114f85') throw new Error('Round-trip failed');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/version/stringify.spec.ts
+++ b/helpers/version/stringify.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { parse } from './parse';
+import { stringify } from './stringify';
+
+const arbitraryVersion = fc
+  .tuple(fc.nat(99), fc.nat(99), fc.nat(99))
+  .map(([major, minor, patch]) => `${major}.${minor}.${patch}`);
+
+const arbitraryPrereleaseVersion = fc
+  .tuple(fc.nat(99), fc.nat(99), fc.nat(99), fc.constantFrom('alpha', 'beta', 'rc'), fc.nat(20))
+  .map(([major, minor, patch, label, n]) => `${major}.${minor}.${patch}-${label}.${n}`);
+
+describe('stringify — property-based', () => {
+  it('round-trips stable versions through parse', () => {
+    fc.assert(
+      fc.property(arbitraryVersion, (v) => {
+        expect(stringify(parse(v))).toBe(v);
+      }),
+    );
+  });
+
+  it('round-trips prerelease versions through parse', () => {
+    fc.assert(
+      fc.property(arbitraryPrereleaseVersion, (v) => {
+        expect(stringify(parse(v))).toBe(v);
+      }),
+    );
+  });
+
+  it('result never starts with "v"', () => {
+    fc.assert(
+      fc.property(arbitraryVersion, (v) => {
+        expect(stringify(parse(v))).not.toMatch(/^v/);
+      }),
+    );
+  });
+
+  it('stable version result contains no "-"', () => {
+    fc.assert(
+      fc.property(arbitraryVersion, (v) => {
+        expect(stringify(parse(v))).not.toContain('-');
+      }),
+    );
+  });
+});
+
+describe('stringify — contract', () => {
+  it('null passthrough', () => expect(stringify(null)).toBeNull());
+  it('undefined passthrough', () => expect(stringify(undefined)).toBeUndefined());
+  it('result for stable version has format X.Y.Z', () => {
+    expect(stringify({ major: 1, minor: 2, patch: 3, prerelease: [], build: [] })).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/helpers/version/stringify.test.ts
+++ b/helpers/version/stringify.test.ts
@@ -1,0 +1,45 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parse } from './parse';
+import { stringify } from './stringify';
+
+describe('stringify — stable versions', () => {
+  it('1.2.3', () => expect(stringify({ major: 1, minor: 2, patch: 3, prerelease: [], build: [] })).toBe('1.2.3'));
+  it('0.0.0', () => expect(stringify({ major: 0, minor: 0, patch: 0, prerelease: [], build: [] })).toBe('0.0.0'));
+  it('10.20.30', () => expect(stringify({ major: 10, minor: 20, patch: 30, prerelease: [], build: [] })).toBe('10.20.30'));
+});
+
+describe('stringify — prerelease versions', () => {
+  it('2.0.0-alpha.1', () =>
+    expect(stringify({ major: 2, minor: 0, patch: 0, prerelease: ['alpha', '1'], build: [] })).toBe('2.0.0-alpha.1'));
+  it('1.0.0-beta', () =>
+    expect(stringify({ major: 1, minor: 0, patch: 0, prerelease: ['beta'], build: [] })).toBe('1.0.0-beta'));
+  it('3.0.0-rc.0', () =>
+    expect(stringify({ major: 3, minor: 0, patch: 0, prerelease: ['rc', '0'], build: [] })).toBe('3.0.0-rc.0'));
+  it('1.0.0-0.3.7', () =>
+    expect(stringify({ major: 1, minor: 0, patch: 0, prerelease: ['0', '3', '7'], build: [] })).toBe('1.0.0-0.3.7'));
+});
+
+describe('stringify — build metadata', () => {
+  it('2.0.0+build.123', () =>
+    expect(stringify({ major: 2, minor: 0, patch: 0, prerelease: [], build: ['build', '123'] })).toBe('2.0.0+build.123'));
+  it('1.0.0-beta+exp.sha.5114f85', () =>
+    expect(stringify({ major: 1, minor: 0, patch: 0, prerelease: ['beta'], build: ['exp', 'sha', '5114f85'] })).toBe('1.0.0-beta+exp.sha.5114f85'));
+});
+
+describe('stringify — null / undefined passthrough', () => {
+  it('undefined → undefined', () => expect(stringify(undefined)).toBeUndefined());
+  it('null → null', () => expect(stringify(null)).toBeNull());
+});
+
+describe('stringify — round-trips with parse', () => {
+  const versions = ['1.2.3', '2.0.0-alpha.1', '1.0.0-rc.0', '2.0.0+build.123', '1.0.0-beta+exp.sha.5114f85'];
+  for (const v of versions) {
+    it(`round-trips ${v}`, () => expect(stringify(parse(v))).toBe(v));
+  }
+});

--- a/helpers/version/stringify.ts
+++ b/helpers/version/stringify.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import type { ParsedVersion } from './parse';
+
+/**
+ * Reconstruct a semantic version string from a {@link ParsedVersion} object.
+ *
+ * This is the inverse of {@link parse}:
+ * `stringify(parse(v)) === stripV(v)` for any valid SemVer string `v`.
+ *
+ * @param parsed - A parsed semantic version object.
+ * @returns The reconstructed version string (without leading `v`).
+ * @example
+ * stringify({ major: 1, minor: 2, patch: 3, prerelease: [], build: [] })
+ * // => '1.2.3'
+ * @example
+ * stringify({ major: 2, minor: 0, patch: 0, prerelease: ['alpha', '1'], build: [] })
+ * // => '2.0.0-alpha.1'
+ * @example
+ * stringify({ major: 1, minor: 0, patch: 0, prerelease: ['beta'], build: ['exp', 'sha', '5114f85'] })
+ * // => '1.0.0-beta+exp.sha.5114f85'
+ * @since next
+ */
+export function stringify(parsed: ParsedVersion): string;
+export function stringify(parsed: undefined): undefined;
+export function stringify(parsed: null): null;
+export function stringify(parsed: ParsedVersion | undefined | null): string | undefined | null {
+  if (parsed === undefined || parsed === null) return parsed;
+  const base = `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+  const prerelease = parsed.prerelease.length > 0 ? `-${parsed.prerelease.join('.')}` : '';
+  const build = parsed.build.length > 0 ? `+${parsed.build.join('.')}` : '';
+  return `${base}${prerelease}${build}`;
+}

--- a/scripts/build/build-website-metadata.ts
+++ b/scripts/build/build-website-metadata.ts
@@ -238,6 +238,7 @@ function processMember(child: DeclarationReflection): WebsiteFunction | undefine
   const examples = extractExamples(comment?.blockTags as CommentTag[] | undefined);
 
   // For type aliases: build the `type Name<T> = ...` definition string
+  // For interfaces: build the `interface Name { ... }` definition string
   let typeDefinition: string | undefined;
   if (kind === 'type' && (child as unknown as Record<string, unknown>).type) {
     const rawType = (child as unknown as Record<string, unknown>).type;
@@ -252,6 +253,15 @@ function processMember(child: DeclarationReflection): WebsiteFunction | undefine
       .join(', ');
     const generics = typeParams ? `<${typeParams}>` : '';
     typeDefinition = `type ${child.name}${generics} = ${typeStr}`;
+  } else if (kind === 'interface') {
+    const members = ((child as unknown as Record<string, unknown>).children as DeclarationReflection[] | undefined) ?? [];
+    const props = members.map(m => {
+      const opt = (m.flags as unknown as Record<string, unknown>)?.isOptional ? '?' : '';
+      return `  ${m.name}${opt}: ${serializeType(m.type)}`;
+    }).join(';\n');
+    typeDefinition = members.length > 0
+      ? `interface ${child.name} {\n${props};\n}`
+      : `interface ${child.name} {}`;
   }
 
   // Source file name
@@ -414,7 +424,7 @@ export async function buildWebsiteMetadata(validCategories: string[]): Promise<v
     const companionTypesMap = new Map<string, WebsiteRelatedType[]>();
     const companionTypeNames = new Set<string>();
     for (const fn of functions) {
-      if (fn.kind !== 'type') continue;
+      if (fn.kind !== 'type' && fn.kind !== 'interface') continue;
       const sharedWithFunctions = funcNamesBySourceFile.get(fn.sourceFile) ?? [];
       if (sharedWithFunctions.length === 1) {
         // 1:1 companion — embed in the function

--- a/scripts/build/build-website-metadata.ts
+++ b/scripts/build/build-website-metadata.ts
@@ -255,12 +255,19 @@ function processMember(child: DeclarationReflection): WebsiteFunction | undefine
     typeDefinition = `type ${child.name}${generics} = ${typeStr}`;
   } else if (kind === 'interface') {
     const members = ((child as unknown as Record<string, unknown>).children as DeclarationReflection[] | undefined) ?? [];
-    const props = members.map(m => {
-      const opt = (m.flags as unknown as Record<string, unknown>)?.isOptional ? '?' : '';
-      return `  ${m.name}${opt}: ${serializeType(m.type)}`;
-    }).join(';\n');
-    typeDefinition = members.length > 0
-      ? `interface ${child.name} {\n${props};\n}`
+    const memberDefinitions = members.flatMap(m => {
+      if (m.kind === ReflectionKind.Property) {
+        const opt = (m.flags as unknown as Record<string, unknown>)?.isOptional ? '?' : '';
+        return [`  ${m.name}${opt}: ${serializeType(m.type)}`];
+      }
+      if (m.signatures?.length) {
+        return m.signatures.map((sig: SignatureReflection) => `  ${buildSignatureString(sig)}`);
+      }
+      return [];
+    });
+    const body = memberDefinitions.join(';\n');
+    typeDefinition = memberDefinitions.length > 0
+      ? `interface ${child.name} {\n${body};\n}`
       : `interface ${child.name} {}`;
   }
 

--- a/scripts/build/helpers/create-bundle-metadata.ts
+++ b/scripts/build/helpers/create-bundle-metadata.ts
@@ -1,17 +1,17 @@
 /**
  * helpers4 - A collection of TypeScript/JavaScript utilities
  * Copyright (C) 2025 baxyz
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -27,39 +27,7 @@ import { ensureDir } from "fs-extra";
 import { DIR } from "../../constants";
 import { readFileJson, writeFile } from "../../utils";
 import { stripV } from "../../../helpers/version/stripV";
-
-/**
- * Derive a GitHub `<owner>/<repo>` slug from a package.json `repository` field.
- * Handles both string and object forms, as well as common URL patterns:
- * - `git+https://github.com/<owner>/<repo>.git`
- * - `https://github.com/<owner>/<repo>`
- * - `git://github.com/<owner>/<repo>.git`
- * - `git@github.com:<owner>/<repo>.git` (SSH)
- * - `git+ssh://git@github.com/<owner>/<repo>.git`
- * - `github:<owner>/<repo>` (npm shorthand)
- * - `<owner>/<repo>` (bare shorthand)
- *
- * @param repository - The `repository` field from package.json.
- * @returns The `<owner>/<repo>` slug, or `undefined` when it cannot be derived.
- */
-function extractGitHubSlug(repository: unknown): string | undefined {
-  const raw =
-    typeof repository === 'string'
-      ? repository
-      : (repository as Record<string, string> | undefined)?.url;
-
-  if (!raw) return undefined;
-
-  // npm shorthands: "github:<owner>/<repo>" or bare "<owner>/<repo>"
-  const shorthand = /^(?:github:)?([\w.-]+\/[\w.-]+)$/.exec(raw);
-  if (shorthand) return shorthand[1];
-
-  // URL-based formats — match the `github.com` hostname followed by the slug
-  const urlMatch = /github\.com[/:]([\w.-]+\/[\w.-]+?)(?:\.git)?(?:[/#?].*)?$/.exec(raw);
-  if (urlMatch) return urlMatch[1];
-
-  return undefined;
-}
+import { parsePackageRepository } from "../../../helpers/url/parsePackageRepository";
 
 /**
  * Create metadata files for the bundle.
@@ -84,9 +52,9 @@ export async function createBundleMetadata(
   // stays correct after any repo rename or fork without touching this file.
   // Supports both string and object forms, and multiple URL patterns.
   const mutationDashboardUrl = (() => {
-    const repoSlug = extractGitHubSlug(rootPackage.repository);
-    if (!repoSlug) return undefined;
-    return `https://dashboard.stryker-mutator.io/reports/github.com/${repoSlug}/v${version}`;
+    const parsed = parsePackageRepository(rootPackage.repository);
+    if (parsed?.host !== 'github' || !parsed.slug) return undefined;
+    return `https://dashboard.stryker-mutator.io/reports/github.com/${parsed.slug}/v${version}`;
   })();
 
   // Runtime compatibility — read from package.json engines field.

--- a/scripts/version/inject-since.ts
+++ b/scripts/version/inject-since.ts
@@ -9,14 +9,7 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 import { isHelperSourceFile } from '../coherency/jsdoc-since/helper';
-
-/**
- * Returns true when the version string has a prerelease suffix
- * (e.g. `2.0.0-alpha.19`, `2.1.0-beta.0`, `3.0.0-rc.1`).
- */
-export function isPrerelease(version: string): boolean {
-  return version.includes('-');
-}
+import { isPrerelease } from '../../helpers/version/isPrerelease';
 
 /**
  * Inject the real version into every helper source file that carries `@since next`.

--- a/scripts/version/inject-since.ts
+++ b/scripts/version/inject-since.ts
@@ -8,6 +8,7 @@
 
 import fs from 'fs-extra';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { isHelperSourceFile } from '../coherency/jsdoc-since/helper';
 import { isPrerelease } from '../../helpers/version/isPrerelease';
 
@@ -78,8 +79,7 @@ export async function injectSinceVersion(
 }
 
 // CLI entry point: tsx scripts/version/inject-since.ts <version> [--dry-run]
-const _executedScript = process.argv[1] ? path.resolve(process.argv[1]).replaceAll(path.sep, '/') : '';
-if (_executedScript !== '' && import.meta.url.endsWith(_executedScript)) {
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const args = process.argv.slice(2);
   const version = args.find(a => !a.startsWith('--'));
   const dryRun = args.includes('--dry-run');

--- a/scripts/version/inject-since.ts
+++ b/scripts/version/inject-since.ts
@@ -83,3 +83,26 @@ export async function injectSinceVersion(
 
   return modified;
 }
+
+// CLI entry point: tsx scripts/version/inject-since.ts <version> [--dry-run]
+const _executedScript = process.argv[1] ? path.resolve(process.argv[1]).replaceAll(path.sep, '/') : '';
+if (_executedScript !== '' && import.meta.url.endsWith(_executedScript)) {
+  const args = process.argv.slice(2);
+  const version = args.find(a => !a.startsWith('--'));
+  const dryRun = args.includes('--dry-run');
+
+  if (!version) {
+    console.error('Usage: tsx scripts/version/inject-since.ts <version> [--dry-run]');
+    process.exit(1);
+  }
+
+  if (isPrerelease(version)) {
+    console.log(`ℹ️  Skipping @since injection — prerelease version (${version}), keeping @since next`);
+    process.exit(0);
+  }
+
+  injectSinceVersion(version, dryRun).catch((err) => {
+    console.error('❌', err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/scripts/version/release.ts
+++ b/scripts/version/release.ts
@@ -9,7 +9,8 @@
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { updateAllPackageVersions } from './version-manager';
-import { injectSinceVersion, isPrerelease } from './inject-since';
+import { injectSinceVersion } from './inject-since';
+import { isPrerelease } from '../../helpers/version/isPrerelease';
 import { createVersionCommitAndTag, getCurrentBranch, isWorkingDirectoryClean } from './git-utils';
 import type { VersionType } from './commit-analyzer';
 


### PR DESCRIPTION
## Summary

This PR covers several independent improvements targeting the `v2.0.0-alpha.20` release.

### CI / Release workflow
- Replace `app-id` with `client-id` for `actions/create-github-app-token` steps (API change)
- Extract website documentation refresh into a dedicated `trigger-website-docs` job (runs after publish, isolated failure scope)

### New helpers
- **`version/isPrerelease`** — detect whether a version string or `ParsedVersion` is a prerelease; handles build metadata (`1.0.0+build-123` → `false`)
- **`version/stringify`** — serialize a `ParsedVersion` back to a string
- **`number/formatSize`** — human-readable byte formatting (B / KB / MB / GB)
- **`url/parsePackageRepository`** — parse the `repository` field of `package.json` into a structured `{ host, slug, owner, repo, gistId, directory }` object; supports all npm-specified formats (shorthand, SSH, HTTPS, gist)

### Script improvements
- `scripts/version/inject-since.ts` — align CLI entry-point guard with `endsWith` pattern used elsewhere; fix false-positive on `1.0.0+build-123` in `isPrerelease`
- `scripts/build/build-website-metadata.ts` — companion-type detection now includes `interface` kinds (fixes `ParsedVersion` incorrectly getting a standalone helper page); interface `typeDefinition` rendering now filters by `ReflectionKind.Property` and handles method signatures

### Tests & quality
- 100% coverage maintained (2868 tests)
- Property-based tests with `fast-check` for `formatSize`, `isPrerelease`, `parsePackageRepository`
- Dead code removed from `parsePackageRepository` (guards made impossible by regex structure)