### PR TITLE
fix(scorecard): wire SCORECARD_TOKEN into scorecard.yml on main

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,6 +29,7 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a


### PR DESCRIPTION
## Summary

`main`'s `scorecard.yml` never had `repo_token: ${{ secrets.SCORECARD_TOKEN }}` — only `v3` did (added in `cb17063`, never merged to `main`).

Every actual Scorecard run (weekly `schedule`, or `workflow_dispatch` without an explicit `--ref`) executes `main`'s workflow definition, not `v3`'s. So the `SCORECARD_TOKEN` secret — despite being correctly configured (fine-grained PAT, `Administration: Read-only` + `Metadata: Read-only`, scoped to this repo) — has never actually been passed to `scorecard-action`, on any run, ever. That's consistent with the PAT showing "Last used: Never" and with `Branch-Protection` scoring `-1` ("some github tokens can't read classic branch protection rules") on every run so far, since all of them ran with the bare default `GITHUB_TOKEN`.

This brings `main` to parity with what `v3` already has.

## Test plan

- [ ] Merge this PR
- [ ] Trigger a manual run: `gh workflow run scorecard.yml --repo helpers4/typescript`
- [ ] Confirm the PAT's "Last used" timestamp updates
- [ ] Confirm `Branch-Protection` no longer scores `-1` via `curl -s https://api.securityscorecards.dev/projects/github.com/helpers4/typescript`

🤖 Generated with [Claude Code](https://claude.com/claude-code)