### PR TITLE
fix(CI-CD): scope post-release contents:write to the mutation job

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   NODE_VERSION: "24"
@@ -17,6 +17,8 @@ jobs:
   mutation:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

`post-release.yml` had `contents: write` at the workflow (top) level, but only the `mutation` job's `gh release upload` step actually needs it — the `coverage` job (`job-tests.yml` reusable workflow) only needs read.

OpenSSF Scorecard's `Token-Permissions` check flags any top-level write permission as excessive when it isn't needed by every job. This scopes it down: top-level defaults to `read`, `mutation` job elevates to `write` locally.

Cherry-picked from `v3` (where this was already fixed) — the Node 24→26 bump present on `v3`'s version of this file is a separate, deliberate breaking change and is intentionally left out of this PR.

## Test plan

- [ ] Merge this PR
- [ ] Confirm `Token-Permissions` no longer flags `post-release.yml:9` via `curl -s https://api.securityscorecards.dev/projects/github.com/helpers4/typescript`
- [ ] Next actual release: confirm mutation reports still upload successfully to the GitHub release (unaffected functionally, permission-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)