### PR TITLE
feat(release): attest and attach SLSA provenance for release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,7 @@ jobs:
     permissions:
       id-token: write
       actions: read
+      attestations: write
     outputs:
       new-version: ${{ needs.build-and-verify.outputs.new-version }}
 
@@ -325,6 +326,28 @@ jobs:
         run: |
           gh release upload "v${{ steps.version.outputs.new-version }}" \
             /tmp/build-meta.tar.gz \
+            --clobber
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+
+      - name: Attest release assets
+        if: ${{ !inputs.dry-run }}
+        id: attest
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: '/tmp/build-meta.tar.gz'
+
+      - name: Upload provenance bundle to release
+        # OpenSSF Scorecard's Signed-Releases check doesn't read the GitHub
+        # Attestations store (see https://github.com/ossf/scorecard/issues/4080) —
+        # it only recognizes a release *asset* whose name ends in `.intoto.jsonl`.
+        # Re-upload the same Sigstore bundle attest-build-provenance already
+        # generated, under that suffix, so both mechanisms point at one artifact.
+        if: ${{ !inputs.dry-run }}
+        run: |
+          cp "${{ steps.attest.outputs.bundle-path }}" /tmp/build-meta.tar.gz.intoto.jsonl
+          gh release upload "v${{ steps.version.outputs.new-version }}" \
+            /tmp/build-meta.tar.gz.intoto.jsonl \
             --clobber
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}


### PR DESCRIPTION
## Summary

`main`'s `release.yml` has never generated build provenance at all — `v3` added `actions/attest-build-provenance` as part of the OpenSSF Scorecard `Signed-Releases` work, but it was never ported back to `main`.

This adds, scoped to only the provenance mechanism:

- `attestations: write` on the `publish` job
- **Attest release assets**: generates a Sigstore/SLSA provenance bundle for `build-meta.tar.gz` via `actions/attest-build-provenance`, stored in the GitHub Attestation Store (verifiable with `gh attestation verify`)
- **Upload provenance bundle to release**: re-uploads that same bundle as a release asset named `build-meta.tar.gz.intoto.jsonl`. OpenSSF Scorecard's `Signed-Releases` check doesn't read the Attestation Store — it only recognizes release *assets* with a `.intoto.jsonl`/`.sig`/etc. suffix ([ossf/scorecard#4080](https://github.com/ossf/scorecard/issues/4080), still open). Naming the same bundle with that suffix satisfies both mechanisms from one artifact.

**Deliberately left out** (present in `v3`'s version of this file but unrelated to provenance): the Node 24→26 bump, and the change allowing prerelease release types to run from any branch. Those are separate `v3` decisions, not part of this fix.

## Test plan

- [ ] Merge this PR
- [ ] Next real release: confirm `build-meta.tar.gz.intoto.jsonl` appears in the release assets (`gh release view vX.Y.Z --json assets`)
- [ ] Confirm `gh attestation verify build-meta.tar.gz --repo helpers4/typescript` still succeeds
- [ ] Confirm `Signed-Releases` score improves via `curl -s https://api.securityscorecards.dev/projects/github.com/helpers4/typescript` (only observable after an actual release, not a Scorecard-only rescan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)