### PR TITLE
To 3.0.3

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -198,3 +198,52 @@ Legend: 🔴 High priority · 🟡 Medium · 🟢 Low
   through classic `typescript@^6`. `tsgo` (`@typescript/native-preview`) is still a preview/dev
   build without full emit parity — revisit at each new tsgo release rather than migrating now,
   since `.d.ts` output is a published deliverable, not an internal detail.
+
+---
+
+## 7. Competitive gap analysis (2026-07-19)
+
+> Researched which lodash/ramda-style competitors are still actively maintained, beyond
+> radashi/remeda (already in `website`'s comparisons). Found: **es-toolkit** (Toss-backed, very
+> active), **rambda** (TS-native Ramda alternative), **moderndash** (smaller, newer). Full
+> writeups live in the `website` repo's `comparisons/` pages — this section is the "what's
+> actually missing from helpers4" distillation, prioritized. `@mobily/ts-belt` checked and
+> excluded (last published 2023-01-10, not active). Effect-TS excluded — different category
+> (FP platform/runtime, not a utility library).
+
+- [ ] 🔴 **`Map`/`Set` utilities — a whole missing category.** es-toolkit ships full parallel
+  utility sets for native `Map`/`Set` (`forEach`, `filter`, `map`, `reduce`, `some`, `every`,
+  `keyBy`, `countBy`, `findKey`/`findValue`). helpers4 currently has **zero** manipulation
+  utilities for these — only guards (`isMap`, `isSet`). Highest priority because it's not a
+  missing function here and there, it's an entire category gap, and `Map`/`Set` are common
+  first-class collections in modern TS code. Needs a design decision: new `@helpers4/map` +
+  `@helpers4/set` categories, or fold into an existing one? Probably not — precedent here is one
+  category per collection-ish concern (`array`, `object`), so two new categories is likely the
+  right shape, not a bolt-on.
+- [ ] 🟡 **Concurrency primitives in `@helpers4/promise`.** Converges across *two* competitors
+  independently — es-toolkit has `Mutex`, `Semaphore`, `delay`, `timeout`/`withTimeout`;
+  moderndash has `sleep`, `timeout`, `retry`, `Queue`. helpers4's `@helpers4/promise` has
+  `settle`/`parallel`/`parallelSettle`/typed guards but no lock/semaphore primitives, no generic
+  `delay`, no `withTimeout` wrapper. `delay` and `withTimeout` are the cheapest, most clearly
+  in-scope additions; `Mutex`/`Semaphore` are a bigger design surface (stateful, class-shaped —
+  first non-trivial departure from this repo's all-functions convention, worth a deliberate
+  decision rather than copying es-toolkit's shape by default).
+- [ ] 🟡 **Number statistics: `median`, `percentile`, `*By` iteratee variants.** helpers4's
+  `@helpers4/array` has `mean`/`sum` but no `median`, no `percentile`, and no iteratee variants
+  (`meanBy`/`sumBy`) — both es-toolkit and moderndash have `median`. Cheap, well-scoped, no
+  design ambiguity — good candidate for a first-timer/contributor issue (see §3).
+- [ ] 🟢 **Bulk object-key case transforms: `toCamelCaseKeys`/`toSnakeCaseKeys`.** es-toolkit
+  recursively transforms every key of an object to a case style in one call; helpers4 has
+  `camelCase`/`snakeCase` for individual strings but nothing that walks an object's keys in bulk.
+  Lower priority than the above — real gap, but narrower use case.
+- [ ] 🟢 **Async-aware array iteration** (`mapAsync`/`filterAsync`/`forEachAsync` with optional
+  concurrency limiting, à la es-toolkit's `limitAsync`). Not a clear add: helpers4 already has
+  `parallel`/`parallelSettle` as standalone promise helpers covering similar ground — this would
+  need a real design pass to decide whether `Array.prototype`-shaped async methods add enough
+  over composing the existing promise helpers to be worth a second API surface for the same
+  problem. Flagging as "needs discussion," not "needs implementation."
+- [ ] 🟢 **Environment/JSON guards**: `isBrowser`/`isNode` (environment detection), `isJSON`/
+  `isJSONArray`/`isJSONObject`/`isJSONValue` (JSON-shape validation), `isLength` (valid
+  array-like length) — all present in es-toolkit, absent from `@helpers4/guard`. Lowest priority
+  of this list: genuinely useful but narrow, no urgency signal from more than one competitor
+  (unlike the concurrency-primitives finding above).

--- a/TODO.md
+++ b/TODO.md
@@ -211,39 +211,72 @@ Legend: 🔴 High priority · 🟡 Medium · 🟢 Low
 > excluded (last published 2023-01-10, not active). Effect-TS excluded — different category
 > (FP platform/runtime, not a utility library).
 
-- [ ] 🔴 **`Map`/`Set` utilities — a whole missing category.** es-toolkit ships full parallel
-  utility sets for native `Map`/`Set` (`forEach`, `filter`, `map`, `reduce`, `some`, `every`,
-  `keyBy`, `countBy`, `findKey`/`findValue`). helpers4 currently has **zero** manipulation
-  utilities for these — only guards (`isMap`, `isSet`). Highest priority because it's not a
-  missing function here and there, it's an entire category gap, and `Map`/`Set` are common
-  first-class collections in modern TS code. Needs a design decision: new `@helpers4/map` +
-  `@helpers4/set` categories, or fold into an existing one? Probably not — precedent here is one
-  category per collection-ish concern (`array`, `object`), so two new categories is likely the
-  right shape, not a bolt-on.
-- [ ] 🟡 **Concurrency primitives in `@helpers4/promise`.** Converges across *two* competitors
-  independently — es-toolkit has `Mutex`, `Semaphore`, `delay`, `timeout`/`withTimeout`;
-  moderndash has `sleep`, `timeout`, `retry`, `Queue`. helpers4's `@helpers4/promise` has
-  `settle`/`parallel`/`parallelSettle`/typed guards but no lock/semaphore primitives, no generic
-  `delay`, no `withTimeout` wrapper. `delay` and `withTimeout` are the cheapest, most clearly
-  in-scope additions; `Mutex`/`Semaphore` are a bigger design surface (stateful, class-shaped —
-  first non-trivial departure from this repo's all-functions convention, worth a deliberate
-  decision rather than copying es-toolkit's shape by default).
-- [ ] 🟡 **Number statistics: `median`, `percentile`, `*By` iteratee variants.** helpers4's
-  `@helpers4/array` has `mean`/`sum` but no `median`, no `percentile`, and no iteratee variants
-  (`meanBy`/`sumBy`) — both es-toolkit and moderndash have `median`. Cheap, well-scoped, no
-  design ambiguity — good candidate for a first-timer/contributor issue (see §3).
-- [ ] 🟢 **Bulk object-key case transforms: `toCamelCaseKeys`/`toSnakeCaseKeys`.** es-toolkit
-  recursively transforms every key of an object to a case style in one call; helpers4 has
-  `camelCase`/`snakeCase` for individual strings but nothing that walks an object's keys in bulk.
-  Lower priority than the above — real gap, but narrower use case.
+- [x] 🔴 **`Map`/`Set` utilities** (2026-07-19, revised same day after checking against native
+  JS) — added as two separate categories, not a combined `@helpers4/collection`: the repo's own
+  precedent (`array`/`object` share `compact`/`equalsShallow` **on purpose**, documented in
+  `CONTRIBUTING.md`'s "Intentional cross-category duplicates") already answers "one category
+  per type vs. one for the operation-kind" in favor of per-type, and `guard`/`type` (the
+  operation-kind categories) don't fit Map/Set's shape.
+  `@helpers4/map` (11 functions): `filter`, `reduce`, `some`, `every`, `countBy`, `toMapByKey`,
+  `findKey`, `findValue`, `hasValue`, `mapKeys`, `mapValues`.
+  `@helpers4/set` (4 functions): `filter`, `countBy`, `toMapByKey`, `map`.
+  (`keyBy` renamed to `toMapByKey` after review — lodash's `_.keyBy` returns a plain object,
+  not a `Map`, so the bare name risked exactly that wrong assumption; the `to<Type>` prefix
+  disambiguates the same way `toSorted`/`toReversed` do.)
+  **Checked against native JS on the actual Node 26 baseline before finalizing** (not just
+  assumed) — dropped 6 of the originally-planned functions as genuine duplicates:
+  `map.forEach`/`set.forEach` (native `Map`/`Set.prototype.forEach` already exist, identical
+  signature) and `set.reduce`/`some`/`every`/`find` (native since Node 22's Iterator Helpers —
+  `set.values().reduce/some/every/find(fn)` — and unlike `Map`, `Set` already iterates plain
+  values with no tuple to destructure, so there was no real convenience left to add). Kept
+  `map`'s `reduce`/`some`/`every`/`findKey`/`findValue`/`hasValue` — those *do* still save a
+  `[key, value]` tuple destructure over the native `map.entries().foo()` equivalent. Documented
+  all of this (including what's *not* implemented and why) in `docs/native-alternatives.json`'s
+  new `map`/`set` sections, consumed by the website build.
+- [x] 🟡 **Number statistics: `median`, `percentile`, `meanBy`, `sumBy`** (2026-07-19) — added to
+  `@helpers4/array` alongside the existing `mean`/`sum`. `percentile` uses linear interpolation
+  between closest ranks (so `percentile(arr, 50)` matches `median`).
+- [x] 🟢 **Bulk object-key case transforms** (2026-07-19, revised same day after review) — landed
+  as **5** functions, not 2: `camelCaseKeys`, `snakeCaseKeys`, `kebabCaseKeys`, `pascalCaseKeys`,
+  `titleCaseKeys` (renamed from the original `toCamelCaseKeys`/`toSnakeCaseKeys` — dropped the
+  `to` prefix to match `@helpers4/string`'s own naming: `camelCase`/`snakeCase`/`kebabCase`, no
+  `to`). Also added `@helpers4/object/mapDeep` — the recursive sibling to the existing `map`
+  (same shallow/deep pairing convention as `clone`/`cloneDeep`) — and rebuilt all 5 `*Keys`
+  functions as thin wrappers over it instead of each hand-rolling its own recursion.
+  Found along the way: `@helpers4/string`'s `camelCase`/`kebabCase` are narrower than their
+  siblings — `camelCase` only handles kebab-case input, `kebabCase` only handles
+  camelCase/PascalCase input, unlike `snakeCase`/`pascalCase`/`titleCase` which all handle any
+  input format. `snakeCaseKeys`/`pascalCaseKeys`/`titleCaseKeys` reuse those public (already
+  robust) functions directly; `camelCaseKeys`/`kebabCaseKeys` use a local, equally-robust
+  `words()`-based helper instead (`object/_caseKeysHelpers.ts`) so they work correctly regardless
+  of whether/when `camelCase`/`kebabCase` themselves get fixed — see the follow-up item below.
+  Also added `sortKeys` (shallow) as a closely-related function while in this area.
+- [x] 🟡 **Fixed `@helpers4/string`'s `camelCase`/`kebabCase` narrowness** (2026-07-19) — both
+  now tokenize the same way `snakeCase`/`pascalCase`/`titleCase` already did (handle
+  snake_case/kebab-case/PascalCase/spaces, not just one specific input format each). Real
+  **`BREAKING CHANGE`** to shipped functions (`@since 1.9.0`) — e.g. `camelCase('-leading')`
+  now returns `'leading'`, not `'Leading'`; `camelCase('UPPER-CASE')` now returns `'upperCase'`,
+  not `'UPPER-CASE'` unchanged. `camelCaseKeys`/`kebabCaseKeys` dropped their local
+  `_caseKeysHelpers.ts` workaround (deleted) and now delegate to the public functions directly,
+  same as the other three `*Keys` variants.
+- [x] 🟢 **Environment/JSON guards** (2026-07-19) — added `isBrowser`, `isNode`, `isLength`,
+  `isJSONValue`, `isJSONArray`, `isJSONObject` to `@helpers4/guard`. `isJSON` ended up with a
+  more useful, distinct meaning than a plain alias: checks whether a **string** is valid
+  parseable JSON (pairs with `@helpers4/object`'s `safeJsonParse`), rather than duplicating
+  `isJSONValue`'s already-parsed-value shape check.
+- [ ] 🟡 **Concurrency primitives in `@helpers4/promise` — narrower than originally scoped.**
+  `delay` (since v1.9.0) and `timeout`/`withTimeout` (since v2.0.0, with its own `TimeoutError`)
+  **already existed** — the original gap-analysis entry was wrong on these two. Only
+  `Mutex`/`Semaphore` remain a real gap. Explained the concrete use case (deduplicating
+  concurrent token-refresh calls; rate-limiting calls to an external API) and confirmed it's
+  worth doing, **but deliberately left out of the 2026-07-19 implementation pass** — bigger
+  design surface (would be this repo's first stateful/class-shaped API — every other export
+  here is a plain function) and needs its own decision, not a default "copy es-toolkit's shape."
+  If picked up: factory functions (`createMutex()`/`createSemaphore()`) were the leaning, to stay
+  function-shaped rather than `export class`.
 - [ ] 🟢 **Async-aware array iteration** (`mapAsync`/`filterAsync`/`forEachAsync` with optional
-  concurrency limiting, à la es-toolkit's `limitAsync`). Not a clear add: helpers4 already has
-  `parallel`/`parallelSettle` as standalone promise helpers covering similar ground — this would
-  need a real design pass to decide whether `Array.prototype`-shaped async methods add enough
-  over composing the existing promise helpers to be worth a second API surface for the same
-  problem. Flagging as "needs discussion," not "needs implementation."
-- [ ] 🟢 **Environment/JSON guards**: `isBrowser`/`isNode` (environment detection), `isJSON`/
-  `isJSONArray`/`isJSONObject`/`isJSONValue` (JSON-shape validation), `isLength` (valid
-  array-like length) — all present in es-toolkit, absent from `@helpers4/guard`. Lowest priority
-  of this list: genuinely useful but narrow, no urgency signal from more than one competitor
-  (unlike the concurrency-primitives finding above).
+  concurrency limiting, à la es-toolkit's `limitAsync`). Deliberately left out of the 2026-07-19
+  pass — real overlap with existing `parallel`/`parallelSettle`, needs a design pass to decide
+  whether `Array.prototype`-shaped async methods add enough over composing the existing promise
+  helpers to justify a second API surface for the same problem. Still "needs discussion," not
+  "needs implementation."

--- a/docs/native-alternatives.json
+++ b/docs/native-alternatives.json
@@ -279,7 +279,7 @@
       "native": "Map.groupBy(map.entries(), ([k, v]) => groupFn(v, k))",
       "since": "ES2024",
       "example": "Map.groupBy(map.entries(), ([k, v]) => v % 2 === 0 ? 'even' : 'odd')",
-      "notes": "Map.groupBy groups into arrays of matching entries (multiple items per key) — not the same as countBy (counts per group) or keyBy (single last-write-wins item per key). Deriving either from Map.groupBy's output is a real extra step, so both remain genuinely useful."
+      "notes": "Map.groupBy groups into arrays of matching entries (multiple items per key) — not the same as countBy (counts per group) or the classic keyBy idea (single last-write-wins item per key, implemented here as toMapByKey — see that function's own docs for why it's not named keyBy). Deriving either from Map.groupBy's output is a real extra step, so both remain genuinely useful."
     }
   ],
   "set": [
@@ -321,7 +321,7 @@
       "native": "Map.groupBy(set.values(), fn)",
       "since": "ES2024",
       "example": "Map.groupBy(set.values(), v => v % 2 === 0 ? 'even' : 'odd')",
-      "notes": "Same distinction as helpers4/map's countBy/keyBy: Map.groupBy groups into arrays, it doesn't count or index-by-last-write."
+      "notes": "Same distinction as helpers4/map's countBy/toMapByKey: Map.groupBy groups into arrays, it doesn't count or index-by-last-write."
     },
     {
       "name": "union / intersection / difference / symmetricDifference",

--- a/docs/native-alternatives.json
+++ b/docs/native-alternatives.json
@@ -234,6 +234,107 @@
       "notes": "For deep merge, use mergeDeep from helpers4"
     }
   ],
+  "map": [
+    {
+      "name": "forEach",
+      "libraries": [
+        "es-toolkit"
+      ],
+      "native": "Map.prototype.forEach((value, key, map) => ...)",
+      "since": "ES2015",
+      "example": "map.forEach((value, key) => console.log(key, value))",
+      "notes": "Not implemented — native Map.prototype.forEach already has this exact (value, key, map) signature, nothing to add."
+    },
+    {
+      "name": "reduce / some / every",
+      "libraries": [
+        "es-toolkit"
+      ],
+      "native": "map.entries().reduce(fn, init) / .some(fn) / .every(fn)",
+      "since": "ES2025 (Iterator Helpers)",
+      "example": "map.entries().reduce((acc, [k, v]) => acc + v, 0)\nmap.entries().some(([k, v]) => v > 10)",
+      "notes": "Iterator Helpers make these one-liners on map.entries()/.values() — but the callback receives a [key, value] tuple to destructure every time. helpers4/map's versions take (value, key) directly, matching Map.prototype.forEach's own argument order, so they're still provided."
+    },
+    {
+      "name": "findKey / findValue",
+      "libraries": [],
+      "native": "map.entries().find(([k, v]) => pred(v, k))?.[0 or 1]",
+      "since": "ES2025 (Iterator Helpers)",
+      "example": "map.entries().find(([k, v]) => v > 10)?.[0]  // key\nmap.entries().find(([k, v]) => v > 10)?.[1]  // value",
+      "notes": "Composable via Iterator Helpers' .find(), but needs a tuple destructure plus an optional-chained index every call site — helpers4/map's versions are still provided for that reason."
+    },
+    {
+      "name": "hasValue",
+      "libraries": [],
+      "native": "map.values().some(v => Object.is(v, value))",
+      "since": "ES2025 (Iterator Helpers)",
+      "example": "map.values().some(v => Object.is(v, target))",
+      "notes": "Thin wrapper for readability — Map.prototype.has() checks keys, not values, which is the actual reason this needs its own name."
+    },
+    {
+      "name": "countBy / keyBy",
+      "libraries": [
+        "es-toolkit"
+      ],
+      "native": "Map.groupBy(map.entries(), ([k, v]) => groupFn(v, k))",
+      "since": "ES2024",
+      "example": "Map.groupBy(map.entries(), ([k, v]) => v % 2 === 0 ? 'even' : 'odd')",
+      "notes": "Map.groupBy groups into arrays of matching entries (multiple items per key) — not the same as countBy (counts per group) or keyBy (single last-write-wins item per key). Deriving either from Map.groupBy's output is a real extra step, so both remain genuinely useful."
+    }
+  ],
+  "set": [
+    {
+      "name": "forEach",
+      "libraries": [
+        "es-toolkit"
+      ],
+      "native": "Set.prototype.forEach((value, value2, set) => ...)",
+      "since": "ES2015",
+      "example": "set.forEach(value => console.log(value))",
+      "notes": "Not implemented — native Set.prototype.forEach already covers this."
+    },
+    {
+      "name": "reduce / some / every / find",
+      "libraries": [
+        "es-toolkit"
+      ],
+      "native": "set.values().reduce(fn, init) / .some(fn) / .every(fn) / .find(fn)",
+      "since": "ES2025 (Iterator Helpers)",
+      "example": "set.values().reduce((acc, v) => acc + v, 0)\nset.values().find(v => v > 10)",
+      "notes": "Not implemented — unlike Map (whose entries are [key, value] tuples needing a destructure), Set already iterates plain values with no shape mismatch against these native methods. There's no real convenience left to add over calling them directly on set.values()."
+    },
+    {
+      "name": "map / filter",
+      "libraries": [
+        "es-toolkit"
+      ],
+      "native": "new Set(set.values().map(fn)) / new Set(set.values().filter(fn))",
+      "since": "ES2025 (Iterator Helpers)",
+      "example": "new Set(set.values().map(v => v * 2))\nnew Set(set.values().filter(v => v > 0))",
+      "notes": "Iterator Helpers give the transform; reconstructing a Set from the result is the part still worth a named helper for."
+    },
+    {
+      "name": "countBy / keyBy",
+      "libraries": [
+        "es-toolkit"
+      ],
+      "native": "Map.groupBy(set.values(), fn)",
+      "since": "ES2024",
+      "example": "Map.groupBy(set.values(), v => v % 2 === 0 ? 'even' : 'odd')",
+      "notes": "Same distinction as helpers4/map's countBy/keyBy: Map.groupBy groups into arrays, it doesn't count or index-by-last-write."
+    },
+    {
+      "name": "union / intersection / difference / symmetricDifference",
+      "libraries": [
+        "lodash",
+        "es-toolkit"
+      ],
+      "native": "Set.prototype.union() / .intersection() / .difference() / .symmetricDifference()",
+      "since": "ES2025 (Set methods)",
+      "example": "setA.union(setB)\nsetA.intersection(setB)\nsetA.difference(setB)",
+      "notes": "Landed natively as of the Set methods proposal — also .isSubsetOf() / .isSupersetOf() / .isDisjointFrom(). Not implemented here; native coverage is already complete for set-algebra operations."
+    }
+  ],
   "string": [
     {
       "name": "trim / trimStart / trimEnd",

--- a/helpers/_shared/_walkPropertyPath.test.ts
+++ b/helpers/_shared/_walkPropertyPath.test.ts
@@ -1,0 +1,53 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { walkPropertyPath } from './_walkPropertyPath';
+
+describe('walkPropertyPath', () => {
+  it('resolves a single-key path', () => {
+    expect(walkPropertyPath({ a: 1 }, ['a'])).toBe(1);
+  });
+
+  it('resolves a multi-key nested path', () => {
+    expect(walkPropertyPath({ a: { b: { c: 42 } } }, ['a', 'b', 'c'])).toBe(42);
+  });
+
+  it('returns the value itself for an empty key list', () => {
+    const value = { a: 1 };
+    expect(walkPropertyPath(value, [])).toBe(value);
+  });
+
+  it('returns undefined when a step resolves to null mid-path', () => {
+    expect(walkPropertyPath({ a: null }, ['a', 'b'])).toBeUndefined();
+  });
+
+  it('returns undefined when a step resolves to a non-object mid-path', () => {
+    expect(walkPropertyPath({ a: 1 }, ['a', 'b'])).toBeUndefined();
+  });
+
+  it('returns undefined for a missing final key', () => {
+    expect(walkPropertyPath({ a: 1 }, ['missing'])).toBeUndefined();
+  });
+
+  it('returns undefined when the root value itself is not an object', () => {
+    expect(walkPropertyPath(42, ['a'])).toBeUndefined();
+  });
+
+  it('walks numeric keys into arrays', () => {
+    expect(walkPropertyPath({ items: ['x', 'y'] }, ['items', 1])).toBe('y');
+  });
+
+  it('walks symbol keys', () => {
+    const id = Symbol('id');
+    expect(walkPropertyPath({ [id]: 'alice' }, [id])).toBe('alice');
+  });
+
+  it('returns undefined when the root value is null or undefined', () => {
+    expect(walkPropertyPath(null, ['a'])).toBeUndefined();
+    expect(walkPropertyPath(undefined, ['a'])).toBeUndefined();
+  });
+});

--- a/helpers/_shared/_walkPropertyPath.ts
+++ b/helpers/_shared/_walkPropertyPath.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Walks a value through a sequence of keys, returning the resolved value or `undefined` if any
+ * step along the way is missing or not an object. Pure traversal only — string-path parsing
+ * (`'a.b.c'` → keys) and default-value substitution are the caller's job.
+ *
+ * Shared by `object/get.ts` and any `*By`-style accessor elsewhere that needs the same
+ * "resolve a path against a value" runtime behavior — kept dependency-free (per the `_shared/`
+ * convention) so it can be used from any category without adding a cross-category import for
+ * this specific piece.
+ * @ignore
+ */
+export function walkPropertyPath(value: unknown, keys: readonly PropertyKey[]): unknown {
+  let result = value;
+  for (const key of keys) {
+    if (result == null || typeof result !== 'object') {
+      return undefined;
+    }
+    result = (result as Record<PropertyKey, unknown>)[key];
+  }
+  return result;
+}

--- a/helpers/array/_byAccessor.test.ts
+++ b/helpers/array/_byAccessor.test.ts
@@ -1,0 +1,31 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { toByAccessorFn } from './_byAccessor';
+
+describe('toByAccessorFn', () => {
+  it('returns the function unchanged when given a function', () => {
+    const fn = (item: { n: number }) => item.n;
+    expect(toByAccessorFn(fn)).toBe(fn);
+  });
+
+  it('resolves a single-key string path', () => {
+    expect(toByAccessorFn<{ price: number }>('price')({ price: 42 })).toBe(42);
+  });
+
+  it('resolves a dot-notation nested string path', () => {
+    expect(toByAccessorFn<{ stats: { score: number } }>('stats.score')({ stats: { score: 7 } })).toBe(7);
+  });
+
+  it('resolves a key array path', () => {
+    expect(toByAccessorFn<{ stats: { score: number } }>(['stats', 'score'])({ stats: { score: 7 } })).toBe(7);
+  });
+
+  it('returns undefined (cast as number) when the path does not resolve', () => {
+    expect(toByAccessorFn<{ a: number }>('missing')({ a: 1 })).toBeUndefined();
+  });
+});

--- a/helpers/array/_byAccessor.ts
+++ b/helpers/array/_byAccessor.ts
@@ -1,0 +1,35 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * Internal helpers shared by sumBy.ts and meanBy.ts.
+ * Not exported from the package barrel — tests live in _byAccessor.test.ts.
+ */
+
+import { walkPropertyPath } from '../_shared/_walkPropertyPath.js';
+import { parsePropertyPath } from '../object/parsePropertyPath.js';
+
+/**
+ * A value-deriving iteratee: either a function, or a dot/bracket-notation string path
+ * (`'a.b.c'`) / explicit key array (`['a', 'b']`) resolved the same way as `@helpers4/object`'s
+ * `get` — shorthand for `item => get(item, path)`.
+ *
+ * Only `sumBy`/`meanBy` accept this form. The sibling `createSortByStringFn` /
+ * `createSortByNumberFn` / `createSortByDateFn` (in `_sortHelpers.ts`) take a `property`
+ * argument that looks the same (a string) but means something different there: a single
+ * literal object key (`item[property]`), not a dot-path — `'a.b'` resolves a nested value here,
+ * but looks up the literal (likely absent) key `'a.b'` there.
+ */
+export type ByAccessor<T> = ((item: T) => number) | string | readonly PropertyKey[];
+
+/**
+ * Normalizes a {@link ByAccessor} into a plain getter function — a function is returned as-is,
+ * a string/key-array path is resolved via `parsePropertyPath` + `walkPropertyPath`.
+ * @ignore
+ */
+export function toByAccessorFn<T>(accessor: ByAccessor<T>): (item: T) => number {
+  if (typeof accessor === 'function') return accessor;
+  const keys = typeof accessor === 'string' ? parsePropertyPath(accessor) : accessor;
+  return (item: T) => walkPropertyPath(item, keys) as number;
+}

--- a/helpers/array/meanBy.example.ts
+++ b/helpers/array/meanBy.example.ts
@@ -1,0 +1,35 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { meanBy } from './meanBy';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'meanBy',
+  category: 'array',
+  examples: [
+    {
+      title: 'Average a property across objects',
+      description: 'Averages a derived numeric value instead of the items themselves.',
+      code: `meanBy([{ price: 10 }, { price: 20 }], item => item.price)
+// => 15`,
+      assert: () => {
+        if (meanBy([{ price: 10 }, { price: 20 }], (item) => item.price) !== 15) throw new Error('Expected 15');
+      },
+    },
+    {
+      title: 'Use a property path instead of a function',
+      description: 'A string (or key array) path is shorthand for a getter function.',
+      code: `meanBy([{ price: 10 }, { price: 20 }], 'price')
+// => 15`,
+      assert: () => {
+        if (meanBy([{ price: 10 }, { price: 20 }], 'price') !== 15) throw new Error('Expected 15');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/array/meanBy.spec.ts
+++ b/helpers/array/meanBy.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { meanBy } from './meanBy';
+
+describe('meanBy — property-based', () => {
+  it('is always between the min and max of the derived values', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer(), { minLength: 1 }), (arr) => {
+        const m = meanBy(arr, (n) => n * 2);
+        const derived = arr.map((n) => n * 2);
+        expect(m).toBeGreaterThanOrEqual(Math.min(...derived));
+        expect(m).toBeLessThanOrEqual(Math.max(...derived));
+      }),
+    );
+  });
+});
+
+describe('meanBy — contract', () => {
+  it('empty array returns NaN', () => {
+    expect(meanBy([], (n: number) => n)).toBeNaN();
+  });
+
+  it('a string path and an equivalent function give the same result', () => {
+    const items = [{ price: 10 }, { price: 20 }, { price: 5 }];
+    expect(meanBy(items, 'price')).toBe(meanBy(items, (item) => item.price));
+  });
+});

--- a/helpers/array/meanBy.test.ts
+++ b/helpers/array/meanBy.test.ts
@@ -1,0 +1,38 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { meanBy } from './meanBy';
+
+describe('meanBy', () => {
+  it('averages a derived value across items', () => {
+    expect(meanBy([{ price: 10 }, { price: 20 }], (item) => item.price)).toBe(15);
+  });
+
+  it('returns NaN for an empty array', () => {
+    expect(meanBy([], (n: number) => n)).toBeNaN();
+  });
+
+  it('works with a single item', () => {
+    expect(meanBy([{ price: 42 }], (item) => item.price)).toBe(42);
+  });
+
+  it('accepts a string property path instead of a function', () => {
+    expect(meanBy([{ price: 10 }, { price: 20 }], 'price')).toBe(15);
+  });
+
+  it('accepts a key array path', () => {
+    expect(meanBy([{ stats: { score: 10 } }, { stats: { score: 20 } }], ['stats', 'score'])).toBe(15);
+  });
+
+  it('returns NaN for null, matching sumBy treating it as empty', () => {
+    expect(meanBy(null, (n: number) => n)).toBeNaN();
+  });
+
+  it('returns NaN for undefined, matching sumBy treating it as empty', () => {
+    expect(meanBy(undefined, (n: number) => n)).toBeNaN();
+  });
+});

--- a/helpers/array/meanBy.ts
+++ b/helpers/array/meanBy.ts
@@ -1,0 +1,33 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import type { ByAccessor } from './_byAccessor.js';
+import { sumBy } from './sumBy.js';
+
+/**
+ * Calculates the arithmetic mean of numbers derived from each item of an array via an iteratee.
+ * Returns `NaN` for an empty array, `null`, or `undefined` — matching {@link sumBy}, which
+ * treats `null`/`undefined` as empty rather than throwing.
+ *
+ * Pairs with {@link sumBy} for aggregate operations.
+ *
+ * @param array - The array of items to average
+ * @param accessor - Function deriving a number from each item, or a property path
+ * @returns The arithmetic mean of the derived values, or `NaN` if the array is empty, `null`, or `undefined`
+ * @example
+ * meanBy([{ price: 10 }, { price: 20 }], item => item.price)
+ * // => 15
+ * meanBy([{ price: 10 }, { price: 20 }], 'price')
+ * // => 15
+ * meanBy(null, item => item.price)
+ * // => NaN
+ * @since next
+ */
+export function meanBy<T>(array: readonly T[] | null | undefined, accessor: ByAccessor<T>): number {
+  const length = array?.length ?? 0;
+  if (length === 0) return NaN;
+  return sumBy(array, accessor) / length;
+}

--- a/helpers/array/median.example.ts
+++ b/helpers/array/median.example.ts
@@ -1,0 +1,35 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { median } from './median';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'median',
+  category: 'array',
+  examples: [
+    {
+      title: 'Odd-length array',
+      description: 'Returns the middle value once sorted.',
+      code: `median([3, 1, 2])
+// => 2`,
+      assert: () => {
+        if (median([3, 1, 2]) !== 2) throw new Error('Expected 2');
+      },
+    },
+    {
+      title: 'Even-length array',
+      description: 'Averages the two middle values.',
+      code: `median([1, 2, 3, 4])
+// => 2.5`,
+      assert: () => {
+        if (median([1, 2, 3, 4]) !== 2.5) throw new Error('Expected 2.5');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/array/median.spec.ts
+++ b/helpers/array/median.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { median } from './median';
+
+describe('median — property-based', () => {
+  it('is always between the min and max of the array', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer(), { minLength: 1 }), (arr) => {
+        const m = median(arr);
+        expect(m).toBeGreaterThanOrEqual(Math.min(...arr));
+        expect(m).toBeLessThanOrEqual(Math.max(...arr));
+      }),
+    );
+  });
+
+  it('does not mutate the input', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer()), (arr) => {
+        const copy = [...arr];
+        median(arr);
+        expect(arr).toEqual(copy);
+      }),
+    );
+  });
+});
+
+describe('median — contract', () => {
+  it('empty array returns NaN', () => {
+    expect(median([])).toBeNaN();
+  });
+});

--- a/helpers/array/median.test.ts
+++ b/helpers/array/median.test.ts
@@ -1,0 +1,36 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { median } from './median';
+
+describe('median', () => {
+  it('returns the middle value for an odd-length array', () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+
+  it('averages the two middle values for an even-length array', () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it('returns the single value for a one-element array', () => {
+    expect(median([42])).toBe(42);
+  });
+
+  it('returns NaN for an empty array', () => {
+    expect(median([])).toBeNaN();
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [3, 1, 2];
+    median(input);
+    expect(input).toEqual([3, 1, 2]);
+  });
+
+  it('handles unsorted input with duplicates', () => {
+    expect(median([5, 1, 5, 2, 5])).toBe(5);
+  });
+});

--- a/helpers/array/median.ts
+++ b/helpers/array/median.ts
@@ -1,0 +1,24 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Calculates the median (middle value) of an array of numbers. For an even-length array,
+ * returns the average of the two middle values. Returns `NaN` for an empty array.
+ * Does not mutate the input array.
+ * @param array - The array of numbers
+ * @returns The median value, or `NaN` if the array is empty
+ * @example
+ * median([1, 2, 3])     // => 2
+ * median([1, 2, 3, 4])  // => 2.5
+ * median([])            // => NaN
+ * @since next
+ */
+export function median(array: readonly number[]): number {
+  if (array.length === 0) return NaN;
+  const sorted = array.toSorted((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}

--- a/helpers/array/median.ts
+++ b/helpers/array/median.ts
@@ -4,10 +4,15 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+import { percentile } from './percentile.js';
+
 /**
  * Calculates the median (middle value) of an array of numbers. For an even-length array,
  * returns the average of the two middle values. Returns `NaN` for an empty array.
  * Does not mutate the input array.
+ *
+ * The median is the 50th {@link percentile} — this delegates to it rather than duplicating
+ * its sort/interpolation logic.
  * @param array - The array of numbers
  * @returns The median value, or `NaN` if the array is empty
  * @example
@@ -17,8 +22,5 @@
  * @since next
  */
 export function median(array: readonly number[]): number {
-  if (array.length === 0) return NaN;
-  const sorted = array.toSorted((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+  return percentile(array, 50);
 }

--- a/helpers/array/percentile.example.ts
+++ b/helpers/array/percentile.example.ts
@@ -1,0 +1,36 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { percentile } from './percentile';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'percentile',
+  category: 'array',
+  examples: [
+    {
+      title: 'Median via the 50th percentile',
+      description: 'The 50th percentile is equivalent to the median.',
+      code: `percentile([1, 2, 3, 4], 50)
+// => 2.5`,
+      assert: () => {
+        if (percentile([1, 2, 3, 4], 50) !== 2.5) throw new Error('Expected 2.5');
+      },
+    },
+    {
+      title: 'Min and max via 0 and 100',
+      description: 'The 0th and 100th percentiles are the min and max.',
+      code: `percentile([4, 1, 3, 2], 0)   // => 1
+percentile([4, 1, 3, 2], 100) // => 4`,
+      assert: () => {
+        if (percentile([4, 1, 3, 2], 0) !== 1) throw new Error('Expected 1');
+        if (percentile([4, 1, 3, 2], 100) !== 4) throw new Error('Expected 4');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/array/percentile.spec.ts
+++ b/helpers/array/percentile.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { percentile } from './percentile';
+
+describe('percentile — property-based', () => {
+  it('is always between the min and max of the array', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.integer(), { minLength: 1 }),
+        fc.integer({ min: 0, max: 100 }),
+        (arr, p) => {
+          const value = percentile(arr, p);
+          expect(value).toBeGreaterThanOrEqual(Math.min(...arr));
+          expect(value).toBeLessThanOrEqual(Math.max(...arr));
+        },
+      ),
+    );
+  });
+
+  it('is monotonically non-decreasing as p increases', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer(), { minLength: 2 }), (arr) => {
+        expect(percentile(arr, 25)).toBeLessThanOrEqual(percentile(arr, 75));
+      }),
+    );
+  });
+
+  it('does not mutate the input', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer()), fc.integer({ min: 0, max: 100 }), (arr, p) => {
+        const copy = [...arr];
+        percentile(arr, p);
+        expect(arr).toEqual(copy);
+      }),
+    );
+  });
+});
+
+describe('percentile — contract', () => {
+  it('empty array returns NaN', () => {
+    expect(percentile([], 50)).toBeNaN();
+  });
+
+  it('50th percentile equals median for an odd-length array', () => {
+    expect(percentile([1, 2, 3], 50)).toBe(2);
+  });
+});

--- a/helpers/array/percentile.test.ts
+++ b/helpers/array/percentile.test.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { percentile } from './percentile';
+
+describe('percentile', () => {
+  it('returns the median at the 50th percentile', () => {
+    expect(percentile([1, 2, 3, 4], 50)).toBe(2.5);
+  });
+
+  it('returns the min at the 0th percentile', () => {
+    expect(percentile([4, 1, 3, 2], 0)).toBe(1);
+  });
+
+  it('returns the max at the 100th percentile', () => {
+    expect(percentile([4, 1, 3, 2], 100)).toBe(4);
+  });
+
+  it('interpolates between ranks', () => {
+    expect(percentile([10, 20, 30, 40], 25)).toBe(17.5);
+  });
+
+  it('returns NaN for an empty array', () => {
+    expect(percentile([], 50)).toBeNaN();
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [3, 1, 2];
+    percentile(input, 50);
+    expect(input).toEqual([3, 1, 2]);
+  });
+
+  it('returns the single value for a one-element array regardless of p', () => {
+    expect(percentile([42], 10)).toBe(42);
+    expect(percentile([42], 90)).toBe(42);
+  });
+});

--- a/helpers/array/percentile.ts
+++ b/helpers/array/percentile.ts
@@ -1,0 +1,32 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Calculates the p-th percentile of an array of numbers using linear interpolation between
+ * the closest ranks. Returns `NaN` for an empty array. Does not mutate the input array.
+ * @param array - The array of numbers
+ * @param p - The percentile to compute, from `0` to `100`
+ * @returns The interpolated value at percentile `p`, or `NaN` if the array is empty
+ * @example
+ * percentile([1, 2, 3, 4], 50)  // => 2.5 (the median)
+ * percentile([1, 2, 3, 4], 0)   // => 1 (the min)
+ * percentile([1, 2, 3, 4], 100) // => 4 (the max)
+ * @since next
+ */
+export function percentile(array: readonly number[], p: number): number {
+  if (array.length === 0) return NaN;
+  const sorted = array.toSorted((a, b) => a - b);
+  if (p <= 0) return sorted[0]!;
+  if (p >= 100) return sorted[sorted.length - 1]!;
+
+  const index = (p / 100) * (sorted.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return sorted[lower]!;
+
+  const fraction = index - lower;
+  return sorted[lower]! + (sorted[upper]! - sorted[lower]!) * fraction;
+}

--- a/helpers/array/sumBy.example.ts
+++ b/helpers/array/sumBy.example.ts
@@ -1,0 +1,35 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { sumBy } from './sumBy';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'sumBy',
+  category: 'array',
+  examples: [
+    {
+      title: 'Sum a property across objects',
+      description: 'Sums a derived numeric value instead of the items themselves.',
+      code: `sumBy([{ price: 10 }, { price: 20 }], item => item.price)
+// => 30`,
+      assert: () => {
+        if (sumBy([{ price: 10 }, { price: 20 }], (item) => item.price) !== 30) throw new Error('Expected 30');
+      },
+    },
+    {
+      title: 'Use a property path instead of a function',
+      description: 'A string (or key array) path is shorthand for a getter function.',
+      code: `sumBy([{ price: 10 }, { price: 20 }], 'price')
+// => 30`,
+      assert: () => {
+        if (sumBy([{ price: 10 }, { price: 20 }], 'price') !== 30) throw new Error('Expected 30');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/array/sumBy.spec.ts
+++ b/helpers/array/sumBy.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { sumBy } from './sumBy';
+
+describe('sumBy — property-based', () => {
+  it('matches summing a mapped array', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer()), (arr) => {
+        expect(sumBy(arr, (n) => n * 2)).toBe(arr.map((n) => n * 2).reduce((a, b) => a + b, 0));
+      }),
+    );
+  });
+});
+
+describe('sumBy — contract', () => {
+  it('null and undefined both return 0', () => {
+    expect(sumBy(null, (n: number) => n)).toBe(0);
+    expect(sumBy(undefined, (n: number) => n)).toBe(0);
+  });
+
+  it('a string path and an equivalent function give the same result', () => {
+    const items = [{ price: 10 }, { price: 20 }, { price: 5 }];
+    expect(sumBy(items, 'price')).toBe(sumBy(items, (item) => item.price));
+  });
+});

--- a/helpers/array/sumBy.test.ts
+++ b/helpers/array/sumBy.test.ts
@@ -1,0 +1,38 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { sumBy } from './sumBy';
+
+describe('sumBy', () => {
+  it('sums a derived value across items', () => {
+    expect(sumBy([{ price: 10 }, { price: 20 }, { price: 5 }], (item) => item.price)).toBe(35);
+  });
+
+  it('returns 0 for an empty array', () => {
+    expect(sumBy([], (n: number) => n)).toBe(0);
+  });
+
+  it('returns 0 for null', () => {
+    expect(sumBy(null, (n: number) => n)).toBe(0);
+  });
+
+  it('returns 0 for undefined', () => {
+    expect(sumBy(undefined, (n: number) => n)).toBe(0);
+  });
+
+  it('accepts a string property path instead of a function', () => {
+    expect(sumBy([{ price: 10 }, { price: 20 }], 'price')).toBe(30);
+  });
+
+  it('accepts a dot-notation nested path', () => {
+    expect(sumBy([{ stats: { score: 3 } }, { stats: { score: 7 } }], 'stats.score')).toBe(10);
+  });
+
+  it('accepts a key array path', () => {
+    expect(sumBy([{ stats: { score: 3 } }, { stats: { score: 7 } }], ['stats', 'score'])).toBe(10);
+  });
+});

--- a/helpers/array/sumBy.ts
+++ b/helpers/array/sumBy.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { toByAccessorFn } from './_byAccessor.js';
+import type { ByAccessor } from './_byAccessor.js';
+
+/**
+ * Calculates the sum of numbers derived from each item of an array via an iteratee.
+ * `null` and `undefined` are treated as empty arrays and return `0`.
+ * @param array - The array of items to sum
+ * @param accessor - Function deriving a number from each item, or a property path
+ * @returns The sum of all derived values, or `0` for an empty array, `null`, or `undefined`
+ * @example
+ * sumBy([{ price: 10 }, { price: 20 }], item => item.price)
+ * // => 30
+ * sumBy([{ price: 10 }, { price: 20 }], 'price')
+ * // => 30
+ * @since next
+ */
+export function sumBy<T>(array: readonly T[] | null | undefined, accessor: ByAccessor<T>): number {
+  if (array == null) return 0;
+  const fn = toByAccessorFn(accessor);
+  return array.reduce((acc, item) => acc + fn(item), 0);
+}

--- a/helpers/guard/isBrowser.example.ts
+++ b/helpers/guard/isBrowser.example.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isBrowser } from './isBrowser';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'isBrowser',
+  category: 'guard',
+  examples: [
+    {
+      title: 'Branch on the runtime environment',
+      description: 'Useful for isomorphic code that behaves differently in the browser vs. Node.js.',
+      code: `if (isBrowser()) {
+  localStorage.setItem('key', 'value')
+} else {
+  // Node.js / server-side fallback
+}`,
+      assert: () => {
+        if (typeof isBrowser() !== 'boolean') throw new Error('Expected a boolean result');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/guard/isBrowser.spec.ts
+++ b/helpers/guard/isBrowser.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isBrowser } from './isBrowser';
+
+describe('isBrowser — property-based', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('matches whether window.document is present, for any window-shaped stub', () => {
+    fc.assert(
+      fc.property(fc.boolean(), (hasDocument) => {
+        vi.stubGlobal('window', hasDocument ? { document: {} } : {});
+        expect(isBrowser()).toBe(hasDocument);
+        vi.unstubAllGlobals();
+      }),
+    );
+  });
+});
+
+describe('isBrowser — contract', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('is false when window itself is missing', () => {
+    vi.stubGlobal('window', undefined);
+    expect(isBrowser()).toBe(false);
+  });
+});

--- a/helpers/guard/isBrowser.test.ts
+++ b/helpers/guard/isBrowser.test.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isBrowser } from './isBrowser';
+
+describe('isBrowser', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns true when window and window.document are both defined', () => {
+    vi.stubGlobal('window', { document: {} });
+    expect(isBrowser()).toBe(true);
+  });
+
+  it('returns false when window is undefined', () => {
+    vi.stubGlobal('window', undefined);
+    expect(isBrowser()).toBe(false);
+  });
+
+  it('returns false when window is defined but window.document is not', () => {
+    vi.stubGlobal('window', {});
+    expect(isBrowser()).toBe(false);
+  });
+});

--- a/helpers/guard/isBrowser.ts
+++ b/helpers/guard/isBrowser.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Checks whether the code is currently running in a browser-like environment
+ * (`window` and `window.document` both defined).
+ *
+ * Note: some hybrid test environments (e.g. happy-dom, jsdom) define both `window` and Node's
+ * `process` at the same time — this only reports on `window`'s presence, it does not imply
+ * `isNode` is false. Use both together if you need to distinguish a real browser from a
+ * DOM-emulating Node test environment.
+ * @returns `true` if `window` and `window.document` are both defined
+ * @example
+ * isBrowser() // => true in a real browser, false in plain Node.js
+ * @since next
+ */
+export function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof window.document !== 'undefined';
+}

--- a/helpers/guard/isJSON.example.ts
+++ b/helpers/guard/isJSON.example.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isJSON } from './isJSON';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'isJSON',
+  category: 'guard',
+  examples: [
+    {
+      title: 'Check a string before parsing it',
+      description: 'Validates that a string is parseable JSON before calling JSON.parse.',
+      code: `isJSON('{"a":1}')
+// => true
+isJSON('not json')
+// => false`,
+      assert: () => {
+        if (!isJSON('{"a":1}')) throw new Error('Expected true');
+        if (isJSON('not json')) throw new Error('Expected false');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/guard/isJSON.spec.ts
+++ b/helpers/guard/isJSON.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { isJSON } from './isJSON';
+
+describe('isJSON — property-based', () => {
+  it('JSON.stringify output is always valid JSON text', () => {
+    fc.assert(
+      fc.property(fc.jsonValue(), (value) => {
+        expect(isJSON(JSON.stringify(value))).toBe(true);
+      }),
+    );
+  });
+
+  it('non-string values are always false', () => {
+    fc.assert(
+      fc.property(fc.anything().filter((v) => typeof v !== 'string'), (value) => {
+        expect(isJSON(value)).toBe(false);
+      }),
+    );
+  });
+});
+
+describe('isJSON — contract', () => {
+  it('empty string is not valid JSON', () => {
+    expect(isJSON('')).toBe(false);
+  });
+});

--- a/helpers/guard/isJSON.test.ts
+++ b/helpers/guard/isJSON.test.ts
@@ -1,0 +1,38 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isJSON } from './isJSON';
+
+describe('isJSON', () => {
+  it('returns true for a valid JSON object string', () => {
+    expect(isJSON('{"a":1}')).toBe(true);
+  });
+
+  it('returns true for a valid JSON array string', () => {
+    expect(isJSON('[1,2,3]')).toBe(true);
+  });
+
+  it('returns true for valid JSON primitives', () => {
+    expect(isJSON('42')).toBe(true);
+    expect(isJSON('"str"')).toBe(true);
+    expect(isJSON('null')).toBe(true);
+    expect(isJSON('true')).toBe(true);
+  });
+
+  it('returns false for malformed JSON', () => {
+    expect(isJSON('{a:1}')).toBe(false);
+    expect(isJSON('not json')).toBe(false);
+    expect(isJSON('')).toBe(false);
+  });
+
+  it('returns false for non-string values', () => {
+    expect(isJSON(42)).toBe(false);
+    expect(isJSON({ a: 1 })).toBe(false);
+    expect(isJSON(null)).toBe(false);
+    expect(isJSON(undefined)).toBe(false);
+  });
+});

--- a/helpers/guard/isJSON.ts
+++ b/helpers/guard/isJSON.ts
@@ -1,0 +1,31 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { safeJsonParse } from '../object/safeJsonParse.js';
+
+// A value JSON.parse can never itself produce, so it safely distinguishes "parse failed"
+// from "parsed successfully to some JSON-representable value" (including `null`).
+const PARSE_FAILED = Symbol('isJSON.parseFailed');
+
+/**
+ * Checks whether a value is a string containing valid, parseable JSON text.
+ *
+ * Distinct from {@link isJSONValue}, which checks an already-parsed runtime value's *shape*
+ * — this checks a *string* before you parse it. Pairs naturally with `@helpers4/object`'s
+ * `safeJsonParse`, which is the safe-parse counterpart once you know the string is valid —
+ * this helper reuses it internally rather than re-implementing the parse/catch itself.
+ * @param value - The value to check
+ * @returns `true` if value is a string and `JSON.parse` succeeds on it
+ * @example
+ * isJSON('{"a":1}')  // => true
+ * isJSON('not json') // => false
+ * isJSON(42)         // => false (not even a string)
+ * @since next
+ */
+export function isJSON(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  return safeJsonParse(value, PARSE_FAILED) !== PARSE_FAILED;
+}

--- a/helpers/guard/isJSONArray.example.ts
+++ b/helpers/guard/isJSONArray.example.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isJSONArray } from './isJSONArray';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'isJSONArray',
+  category: 'guard',
+  examples: [
+    {
+      title: 'Validate a JSON array',
+      description: 'Checks that a value is an array whose every element is JSON-representable.',
+      code: `isJSONArray([1, 'two', null])
+// => true
+isJSONArray([1, undefined])
+// => false`,
+      assert: () => {
+        if (!isJSONArray([1, 'two', null])) throw new Error('Expected true');
+        if (isJSONArray([1, undefined])) throw new Error('Expected false');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/guard/isJSONArray.spec.ts
+++ b/helpers/guard/isJSONArray.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { isJSONArray } from './isJSONArray';
+
+describe('isJSONArray — property-based', () => {
+  it('any array from fc.jsonValue() elements is valid', () => {
+    fc.assert(
+      fc.property(fc.array(fc.jsonValue()), (arr) => {
+        expect(isJSONArray(arr)).toBe(true);
+      }),
+    );
+  });
+});
+
+describe('isJSONArray — contract', () => {
+  it('non-arrays are always false', () => {
+    expect(isJSONArray({})).toBe(false);
+    expect(isJSONArray(null)).toBe(false);
+    expect(isJSONArray('str')).toBe(false);
+  });
+
+  it('empty array is valid', () => {
+    expect(isJSONArray([])).toBe(true);
+  });
+});

--- a/helpers/guard/isJSONArray.test.ts
+++ b/helpers/guard/isJSONArray.test.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isJSONArray } from './isJSONArray';
+
+describe('isJSONArray', () => {
+  it('returns true for an array of JSON values', () => {
+    expect(isJSONArray([1, 'two', null, { a: true }])).toBe(true);
+  });
+
+  it('returns true for an empty array', () => {
+    expect(isJSONArray([])).toBe(true);
+  });
+
+  it('returns false when an element is not a JSON value', () => {
+    expect(isJSONArray([1, undefined])).toBe(false);
+  });
+
+  it('returns false for a non-array', () => {
+    expect(isJSONArray({})).toBe(false);
+    expect(isJSONArray('not an array')).toBe(false);
+    expect(isJSONArray(null)).toBe(false);
+  });
+});

--- a/helpers/guard/isJSONArray.ts
+++ b/helpers/guard/isJSONArray.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isJSONValue } from './isJSONValue';
+
+/**
+ * Checks whether a value is an array whose every element is a valid JSON value
+ * (see {@link isJSONValue}).
+ * @param value - The value to check
+ * @returns `true` if value is an array of JSON values
+ * @example
+ * isJSONArray([1, 'two', null])  // => true
+ * isJSONArray([1, undefined])    // => false
+ * isJSONArray({})                // => false
+ * @since next
+ */
+export function isJSONArray(value: unknown): value is unknown[] {
+  return Array.isArray(value) && value.every(isJSONValue);
+}

--- a/helpers/guard/isJSONObject.example.ts
+++ b/helpers/guard/isJSONObject.example.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isJSONObject } from './isJSONObject';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'isJSONObject',
+  category: 'guard',
+  examples: [
+    {
+      title: 'Validate a JSON object',
+      description: 'Checks that a value is a plain object whose every value is JSON-representable.',
+      code: `isJSONObject({ a: 1, b: 'two' })
+// => true
+isJSONObject({ a: undefined })
+// => false`,
+      assert: () => {
+        if (!isJSONObject({ a: 1, b: 'two' })) throw new Error('Expected true');
+        if (isJSONObject({ a: undefined })) throw new Error('Expected false');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/guard/isJSONObject.spec.ts
+++ b/helpers/guard/isJSONObject.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { isJSONObject } from './isJSONObject';
+
+describe('isJSONObject — property-based', () => {
+  it('any dictionary of fc.jsonValue() is valid', () => {
+    fc.assert(
+      fc.property(fc.dictionary(fc.string(), fc.jsonValue()), (obj) => {
+        expect(isJSONObject(obj)).toBe(true);
+      }),
+    );
+  });
+});
+
+describe('isJSONObject — contract', () => {
+  it('arrays are never JSON objects', () => {
+    expect(isJSONObject([])).toBe(false);
+  });
+
+  it('empty object is valid', () => {
+    expect(isJSONObject({})).toBe(true);
+  });
+});

--- a/helpers/guard/isJSONObject.test.ts
+++ b/helpers/guard/isJSONObject.test.ts
@@ -1,0 +1,34 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isJSONObject } from './isJSONObject';
+
+describe('isJSONObject', () => {
+  it('returns true for a plain object of JSON values', () => {
+    expect(isJSONObject({ a: 1, b: 'two', c: null })).toBe(true);
+  });
+
+  it('returns true for an empty object', () => {
+    expect(isJSONObject({})).toBe(true);
+  });
+
+  it('returns false when a value is not a JSON value', () => {
+    expect(isJSONObject({ a: undefined })).toBe(false);
+  });
+
+  it('returns false for an array', () => {
+    expect(isJSONObject([])).toBe(false);
+  });
+
+  it('returns false for a non-plain object', () => {
+    expect(isJSONObject(new Date())).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isJSONObject(null)).toBe(false);
+  });
+});

--- a/helpers/guard/isJSONObject.ts
+++ b/helpers/guard/isJSONObject.ts
@@ -1,0 +1,23 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isJSONValue } from './isJSONValue';
+import { isPlainObject } from './isPlainObject';
+
+/**
+ * Checks whether a value is a plain object whose every own value is a valid JSON value
+ * (see {@link isJSONValue}).
+ * @param value - The value to check
+ * @returns `true` if value is a plain object of JSON values
+ * @example
+ * isJSONObject({ a: 1, b: 'two' })  // => true
+ * isJSONObject({ a: undefined })    // => false
+ * isJSONObject([])                  // => false
+ * @since next
+ */
+export function isJSONObject(value: unknown): value is Record<string, unknown> {
+  return isPlainObject(value) && Object.values(value).every(isJSONValue);
+}

--- a/helpers/guard/isJSONValue.example.ts
+++ b/helpers/guard/isJSONValue.example.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isJSONValue } from './isJSONValue';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'isJSONValue',
+  category: 'guard',
+  examples: [
+    {
+      title: 'Validate a value before sending it as JSON',
+      description: 'Recursively checks that a value only contains JSON-representable types.',
+      code: `isJSONValue({ a: [1, 'two', null, { b: true }] })
+// => true
+isJSONValue({ a: new Date() })
+// => false`,
+      assert: () => {
+        if (!isJSONValue({ a: [1, 'two', null, { b: true }] })) throw new Error('Expected true');
+        if (isJSONValue({ a: new Date() })) throw new Error('Expected false');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/guard/isJSONValue.spec.ts
+++ b/helpers/guard/isJSONValue.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { isJSONValue } from './isJSONValue';
+
+describe('isJSONValue — property-based', () => {
+  it('any value produced by fc.jsonValue() is valid', () => {
+    fc.assert(
+      fc.property(fc.jsonValue(), (value) => {
+        expect(isJSONValue(value)).toBe(true);
+      }),
+    );
+  });
+
+  it('surviving a JSON.stringify/parse round-trip unchanged implies validity', () => {
+    fc.assert(
+      fc.property(fc.jsonValue(), (value) => {
+        const roundTripped: unknown = JSON.parse(JSON.stringify(value));
+        expect(isJSONValue(roundTripped)).toBe(true);
+      }),
+    );
+  });
+});
+
+describe('isJSONValue — contract', () => {
+  it('undefined is never a JSON value', () => {
+    expect(isJSONValue(undefined)).toBe(false);
+  });
+
+  it('a Date instance is never a JSON value, even though it stringifies', () => {
+    expect(isJSONValue(new Date())).toBe(false);
+  });
+});

--- a/helpers/guard/isJSONValue.test.ts
+++ b/helpers/guard/isJSONValue.test.ts
@@ -1,0 +1,66 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isJSONValue } from './isJSONValue';
+
+describe('isJSONValue', () => {
+  it('returns true for primitives', () => {
+    expect(isJSONValue('str')).toBe(true);
+    expect(isJSONValue(42)).toBe(true);
+    expect(isJSONValue(true)).toBe(true);
+    expect(isJSONValue(null)).toBe(true);
+  });
+
+  it('returns true for a nested plain object/array structure', () => {
+    expect(isJSONValue({ a: [1, 'two', null, { b: true }] })).toBe(true);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isJSONValue(undefined)).toBe(false);
+  });
+
+  it('returns false for functions and symbols', () => {
+    expect(isJSONValue(() => {})).toBe(false);
+    expect(isJSONValue(Symbol('x'))).toBe(false);
+  });
+
+  it('returns false for NaN and Infinity', () => {
+    expect(isJSONValue(Number.NaN)).toBe(false);
+    expect(isJSONValue(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+
+  it('returns false for non-plain objects like Date and Map', () => {
+    expect(isJSONValue(new Date())).toBe(false);
+    expect(isJSONValue(new Map())).toBe(false);
+  });
+
+  it('returns false when a nested value is invalid', () => {
+    expect(isJSONValue({ a: [1, undefined] })).toBe(false);
+  });
+
+  it('handles empty arrays and objects', () => {
+    expect(isJSONValue([])).toBe(true);
+    expect(isJSONValue({})).toBe(true);
+  });
+
+  it('returns false for a circular object instead of overflowing the stack', () => {
+    const obj: Record<string, unknown> = { a: 1 };
+    obj['self'] = obj;
+    expect(isJSONValue(obj)).toBe(false);
+  });
+
+  it('returns false for a circular array instead of overflowing the stack', () => {
+    const arr: unknown[] = [1, 2];
+    arr.push(arr);
+    expect(isJSONValue(arr)).toBe(false);
+  });
+
+  it('a value referenced twice without a cycle is still valid', () => {
+    const shared = { x: 1 };
+    expect(isJSONValue({ a: shared, b: shared })).toBe(true);
+  });
+});

--- a/helpers/guard/isJSONValue.ts
+++ b/helpers/guard/isJSONValue.ts
@@ -1,0 +1,48 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isPlainObject } from './isPlainObject';
+
+function transform(value: unknown, seen: Set<unknown>): boolean {
+  if (value === null) return true;
+  if (typeof value === 'string' || typeof value === 'boolean') return true;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (Array.isArray(value) || isPlainObject(value)) {
+    // A real JSON.stringify/parse round-trip never terminates on a cycle, so treat one as
+    // invalid rather than recursing forever. Popped after this node's subtree is fully
+    // checked, so a value referenced twice without a cycle (a shared, non-circular node) is
+    // still valid.
+    if (seen.has(value)) return false;
+    seen.add(value);
+    try {
+      const items = Array.isArray(value) ? value : Object.values(value);
+      return items.every((item) => transform(item, seen));
+    } finally {
+      seen.delete(value);
+    }
+  }
+  return false;
+}
+
+/**
+ * Checks whether a value is composed entirely of JSON-representable types: `string`, finite
+ * `number`, `boolean`, `null`, arrays of JSON values, or plain objects of JSON values.
+ * `undefined`, functions, symbols, `NaN`/`Infinity`, and non-plain objects (`Date`, `Map`,
+ * `Set`, class instances...) all return `false`, since none survive a real `JSON.stringify` /
+ * `JSON.parse` round-trip unchanged. Circular references also return `false` for the same
+ * reason, instead of recursing forever.
+ * @param value - The value to check
+ * @returns `true` if the value is a valid JSON value
+ * @example
+ * isJSONValue({ a: [1, 'two', null, { b: true }] }) // => true
+ * isJSONValue(new Date())                           // => false
+ * isJSONValue(undefined)                             // => false
+ * isJSONValue(Number.NaN)                             // => false
+ * @since next
+ */
+export function isJSONValue(value: unknown): boolean {
+  return transform(value, new Set());
+}

--- a/helpers/guard/isLength.example.ts
+++ b/helpers/guard/isLength.example.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isLength } from './isLength';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'isLength',
+  category: 'guard',
+  examples: [
+    {
+      title: 'Validate an array-like length before indexing',
+      description: 'Guards against negative, fractional, or unsafe length values.',
+      code: `isLength(3)   // => true
+isLength(-1)  // => false
+isLength(1.5) // => false`,
+      assert: () => {
+        if (!isLength(3) || isLength(-1) || isLength(1.5)) throw new Error('Unexpected result');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/guard/isLength.spec.ts
+++ b/helpers/guard/isLength.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { isLength } from './isLength';
+
+describe('isLength — property-based', () => {
+  it('is true for any non-negative safe integer', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: Number.MAX_SAFE_INTEGER }), (n) => {
+        expect(isLength(n)).toBe(true);
+      }),
+    );
+  });
+
+  it('is false for any negative integer', () => {
+    fc.assert(
+      fc.property(fc.integer({ max: -1 }), (n) => {
+        expect(isLength(n)).toBe(false);
+      }),
+    );
+  });
+
+  it('is false for any non-number value', () => {
+    fc.assert(
+      fc.property(
+        fc.oneof(fc.string(), fc.boolean(), fc.constant(null), fc.constant(undefined)),
+        (value) => {
+          expect(isLength(value)).toBe(false);
+        },
+      ),
+    );
+  });
+});
+
+describe('isLength — contract', () => {
+  it('boundary: MAX_SAFE_INTEGER is valid, one more is not', () => {
+    expect(isLength(Number.MAX_SAFE_INTEGER)).toBe(true);
+    expect(isLength(Number.MAX_SAFE_INTEGER + 2)).toBe(false);
+  });
+});

--- a/helpers/guard/isLength.test.ts
+++ b/helpers/guard/isLength.test.ts
@@ -1,0 +1,42 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isLength } from './isLength';
+
+describe('isLength', () => {
+  it('returns true for zero and positive integers', () => {
+    expect(isLength(0)).toBe(true);
+    expect(isLength(3)).toBe(true);
+  });
+
+  it('returns true for MAX_SAFE_INTEGER', () => {
+    expect(isLength(Number.MAX_SAFE_INTEGER)).toBe(true);
+  });
+
+  it('returns false for negative numbers', () => {
+    expect(isLength(-1)).toBe(false);
+  });
+
+  it('returns false for non-integers', () => {
+    expect(isLength(1.5)).toBe(false);
+  });
+
+  it('returns false for numbers beyond MAX_SAFE_INTEGER', () => {
+    expect(isLength(Number.MAX_SAFE_INTEGER + 2)).toBe(false);
+  });
+
+  it('returns false for non-number types', () => {
+    expect(isLength('3')).toBe(false);
+    expect(isLength(null)).toBe(false);
+    expect(isLength(undefined)).toBe(false);
+  });
+
+  it('returns false for NaN and Infinity', () => {
+    expect(isLength(Number.NaN)).toBe(false);
+    expect(isLength(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});

--- a/helpers/guard/isLength.ts
+++ b/helpers/guard/isLength.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Checks whether a value is a valid array-like `length`: a non-negative safe integer
+ * (`0 <= value <= Number.MAX_SAFE_INTEGER`).
+ * @param value - The value to check
+ * @returns `true` if value is a valid length
+ * @example
+ * isLength(3)      // => true
+ * isLength(0)      // => true
+ * isLength(-1)     // => false
+ * isLength(1.5)    // => false
+ * isLength('3')    // => false
+ * @since next
+ */
+export function isLength(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value <= Number.MAX_SAFE_INTEGER
+  );
+}

--- a/helpers/guard/isNode.example.ts
+++ b/helpers/guard/isNode.example.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { isNode } from './isNode';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'isNode',
+  category: 'guard',
+  examples: [
+    {
+      title: 'Branch on the runtime environment',
+      description: 'Useful for isomorphic code that behaves differently on the server vs. the browser.',
+      code: `if (isNode()) {
+  const fs = await import('node:fs')
+  // server-side file access
+}`,
+      assert: () => {
+        if (typeof isNode() !== 'boolean') throw new Error('Expected a boolean result');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/guard/isNode.spec.ts
+++ b/helpers/guard/isNode.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isNode } from './isNode';
+
+describe('isNode — property-based', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('matches whether process.versions.node is present, for any process-shaped stub', () => {
+    fc.assert(
+      fc.property(fc.boolean(), (hasNode) => {
+        vi.stubGlobal('process', hasNode ? { versions: { node: '26.0.0' } } : { versions: {} });
+        expect(isNode()).toBe(hasNode);
+        vi.unstubAllGlobals();
+      }),
+    );
+  });
+});
+
+describe('isNode — contract', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('is false when process itself is missing', () => {
+    vi.stubGlobal('process', undefined);
+    expect(isNode()).toBe(false);
+  });
+});

--- a/helpers/guard/isNode.test.ts
+++ b/helpers/guard/isNode.test.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isNode } from './isNode';
+
+describe('isNode', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns true in the real Node.js test environment', () => {
+    expect(isNode()).toBe(true);
+  });
+
+  it('returns false when process is undefined', () => {
+    vi.stubGlobal('process', undefined);
+    expect(isNode()).toBe(false);
+  });
+
+  it('returns false when process.versions.node is not a string', () => {
+    vi.stubGlobal('process', { versions: {} });
+    expect(isNode()).toBe(false);
+  });
+});

--- a/helpers/guard/isNode.ts
+++ b/helpers/guard/isNode.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Checks whether the code is currently running in a Node.js-like environment
+ * (`process.versions.node` is defined — also true in Electron's Node context).
+ *
+ * Note: some hybrid test environments (e.g. happy-dom, jsdom) define both `window` and Node's
+ * `process` at the same time — this only reports on `process.versions.node`'s presence, it does
+ * not imply `isBrowser` is false. Use both together if you need to distinguish plain Node.js
+ * from a DOM-emulating Node test environment.
+ * @returns `true` if `process.versions.node` is defined
+ * @example
+ * isNode() // => true in Node.js, false in a real browser
+ * @since next
+ */
+export function isNode(): boolean {
+  return typeof process !== 'undefined' && typeof process.versions?.node === 'string';
+}

--- a/helpers/map/config.json
+++ b/helpers/map/config.json
@@ -1,0 +1,5 @@
+{
+  "label": "Map",
+  "smallDescription": "Native Map manipulation utilities",
+  "description": "Utilities for working with native Map instances: iteration, filtering, transforming keys/values, and building Maps from arrays"
+}

--- a/helpers/map/countBy.example.ts
+++ b/helpers/map/countBy.example.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { countBy } from './countBy';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'countBy',
+  category: 'map',
+  examples: [
+    {
+      title: 'Count entries by parity',
+      description: 'Groups values by a derived key and counts how many fall into each group.',
+      code: `countBy(new Map([['a', 1], ['b', 2], ['c', 3], ['d', 4]]), v => v % 2 === 0 ? 'even' : 'odd')
+// => Map(2) { 'odd' => 2, 'even' => 2 }`,
+      assert: () => {
+        const result = countBy(new Map([['a', 1], ['b', 2], ['c', 3], ['d', 4]]), (v) => (v % 2 === 0 ? 'even' : 'odd'));
+        if (result.get('odd') !== 2 || result.get('even') !== 2) throw new Error('Unexpected counts');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/map/countBy.spec.ts
+++ b/helpers/map/countBy.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { countBy } from './countBy';
+
+describe('countBy — property-based', () => {
+  it('sum of counts equals the map size', () => {
+    fc.assert(
+      fc.property(fc.array(fc.tuple(fc.string(), fc.integer())), (entries) => {
+        const map = new Map(entries);
+        const counts = countBy(map, (v) => v % 3);
+        const total = [...counts.values()].reduce((a, b) => a + b, 0);
+        expect(total).toBe(map.size);
+      }),
+    );
+  });
+});
+
+describe('countBy — contract', () => {
+  it('empty map returns an empty map', () => {
+    expect(countBy(new Map(), () => 'x')).toEqual(new Map());
+  });
+});

--- a/helpers/map/countBy.test.ts
+++ b/helpers/map/countBy.test.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { countBy } from './countBy';
+
+describe('countBy', () => {
+  it('counts entries per derived group', () => {
+    const map = new Map([['a', 1], ['b', 2], ['c', 3], ['d', 4]]);
+    expect(countBy(map, (v) => (v % 2 === 0 ? 'even' : 'odd'))).toEqual(
+      new Map([['odd', 2], ['even', 2]]),
+    );
+  });
+
+  it('returns an empty map for an empty input', () => {
+    expect(countBy(new Map(), (v: number) => v)).toEqual(new Map());
+  });
+
+  it('creates one group per distinct derived key', () => {
+    const map = new Map([['a', 1], ['b', 2], ['c', 3]]);
+    expect(countBy(map, (v) => v)).toEqual(new Map([[1, 1], [2, 1], [3, 1]]));
+  });
+});

--- a/helpers/map/countBy.ts
+++ b/helpers/map/countBy.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Groups the entries of a Map by a derived key and counts how many fall into each group.
+ * @param map - The Map to summarize
+ * @param fn - Function deriving the grouping key from (value, key)
+ * @returns A Map from derived key to the number of entries in that group
+ * @example
+ * countBy(new Map([['a', 1], ['b', 2], ['c', 3]]), value => value % 2 === 0 ? 'even' : 'odd')
+ * // => Map(2) { 'odd' => 2, 'even' => 1 }
+ * @since next
+ */
+export function countBy<K, V, R>(
+  map: ReadonlyMap<K, V>,
+  fn: (value: V, key: K) => R,
+): Map<R, number> {
+  const counts = new Map<R, number>();
+  for (const [key, value] of map) {
+    const group = fn(value, key);
+    counts.set(group, (counts.get(group) ?? 0) + 1);
+  }
+  return counts;
+}

--- a/helpers/map/every.example.ts
+++ b/helpers/map/every.example.ts
@@ -1,0 +1,35 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { every } from './every';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'every',
+  category: 'map',
+  examples: [
+    {
+      title: 'Check that all values are positive',
+      description: 'Returns false as soon as one entry fails the predicate.',
+      code: `every(new Map([['a', 1], ['b', 2]]), value => value > 0)
+// => true`,
+      assert: () => {
+        if (!every(new Map([['a', 1], ['b', 2]]), (v) => v > 0)) throw new Error('Expected true');
+      },
+    },
+    {
+      title: 'Empty map',
+      description: 'Vacuously true for an empty map.',
+      code: `every(new Map(), () => false)
+// => true`,
+      assert: () => {
+        if (!every(new Map(), () => false)) throw new Error('Expected true');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/map/every.spec.ts
+++ b/helpers/map/every.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { every } from './every';
+
+describe('every — property-based', () => {
+  it('matches Array.from(map.values()).every(...)', () => {
+    fc.assert(
+      fc.property(fc.array(fc.tuple(fc.string(), fc.integer())), (entries) => {
+        const map = new Map(entries);
+        expect(every(map, (v) => v > 0)).toBe([...map.values()].every((v) => v > 0));
+      }),
+    );
+  });
+});
+
+describe('every — contract', () => {
+  it('empty map is vacuously true', () => {
+    expect(every(new Map(), () => false)).toBe(true);
+  });
+});

--- a/helpers/map/every.test.ts
+++ b/helpers/map/every.test.ts
@@ -1,0 +1,31 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { every } from './every';
+
+describe('every', () => {
+  it('returns true when all entries match', () => {
+    expect(every(new Map([['a', 1], ['b', 2]]), (v) => v > 0)).toBe(true);
+  });
+
+  it('returns false when at least one entry does not match', () => {
+    expect(every(new Map([['a', 1], ['b', -2]]), (v) => v > 0)).toBe(false);
+  });
+
+  it('returns true (vacuously) for an empty map', () => {
+    expect(every(new Map(), () => false)).toBe(true);
+  });
+
+  it('short-circuits after the first mismatch', () => {
+    let calls = 0;
+    every(new Map([['a', -1], ['b', 2], ['c', 3]]), (v) => {
+      calls++;
+      return v > 0;
+    });
+    expect(calls).toBe(1);
+  });
+});

--- a/helpers/map/every.ts
+++ b/helpers/map/every.ts
@@ -1,0 +1,25 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Checks if every entry of a Map satisfies the predicate. Short-circuits on the first mismatch.
+ * @param map - The Map to check
+ * @param predicate - Function invoked with (value, key)
+ * @returns `true` if all entries match (vacuously `true` for an empty map), `false` otherwise
+ * @example
+ * every(new Map([['a', 1], ['b', 2]]), value => value > 0)
+ * // => true
+ * @since next
+ */
+export function every<K, V>(
+  map: ReadonlyMap<K, V>,
+  predicate: (value: V, key: K) => boolean,
+): boolean {
+  for (const [key, value] of map) {
+    if (!predicate(value, key)) return false;
+  }
+  return true;
+}

--- a/helpers/map/filter.example.ts
+++ b/helpers/map/filter.example.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { filter } from './filter';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'filter',
+  category: 'map',
+  examples: [
+    {
+      title: 'Keep only even values',
+      description: 'Creates a new Map with only the entries whose value satisfies the predicate.',
+      code: `filter(new Map([['a', 1], ['b', 2], ['c', 3]]), value => value % 2 === 0)
+// => Map(1) { 'b' => 2 }`,
+      assert: () => {
+        const result = filter(new Map([['a', 1], ['b', 2], ['c', 3]]), (v) => v % 2 === 0);
+        if (result.size !== 1 || result.get('b') !== 2) throw new Error('Unexpected filter result');
+      },
+    },
+    {
+      title: 'No matches',
+      description: 'Returns an empty Map when nothing matches.',
+      code: `filter(new Map([['a', 1]]), () => false)
+// => Map(0) {}`,
+      assert: () => {
+        const result = filter(new Map([['a', 1]]), () => false);
+        if (result.size !== 0) throw new Error('Expected an empty map');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/map/filter.spec.ts
+++ b/helpers/map/filter.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { filter } from './filter';
+
+describe('filter — property-based', () => {
+  it('result size never exceeds the input size', () => {
+    fc.assert(
+      fc.property(fc.array(fc.tuple(fc.string(), fc.integer())), (entries) => {
+        const map = new Map(entries);
+        const result = filter(map, (v) => v > 0);
+        expect(result.size).toBeLessThanOrEqual(map.size);
+      }),
+    );
+  });
+
+  it('every remaining value satisfies the predicate', () => {
+    fc.assert(
+      fc.property(fc.array(fc.tuple(fc.string(), fc.integer())), (entries) => {
+        const map = new Map(entries);
+        const result = filter(map, (v) => v % 2 === 0);
+        for (const value of result.values()) {
+          expect(value % 2 === 0).toBe(true);
+        }
+      }),
+    );
+  });
+});
+
+describe('filter — contract', () => {
+  it('empty map returns empty map', () => {
+    expect(filter(new Map(), () => true)).toEqual(new Map());
+  });
+});

--- a/helpers/map/filter.test.ts
+++ b/helpers/map/filter.test.ts
@@ -1,0 +1,36 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { filter } from './filter';
+
+describe('filter', () => {
+  it('keeps only entries matching the predicate', () => {
+    const map = new Map([['a', 1], ['b', 2], ['c', 3]]);
+    expect(filter(map, (value) => value % 2 === 0)).toEqual(new Map([['b', 2]]));
+  });
+
+  it('returns an empty map when nothing matches', () => {
+    const map = new Map([['a', 1]]);
+    expect(filter(map, () => false)).toEqual(new Map());
+  });
+
+  it('returns all entries when everything matches', () => {
+    const map = new Map([['a', 1], ['b', 2]]);
+    expect(filter(map, () => true)).toEqual(map);
+  });
+
+  it('does not mutate the original map', () => {
+    const map = new Map([['a', 1], ['b', 2]]);
+    filter(map, (value) => value > 1);
+    expect(map.size).toBe(2);
+  });
+
+  it('passes the key to the predicate', () => {
+    const map = new Map([['keep', 1], ['drop', 2]]);
+    expect(filter(map, (_value, key) => key === 'keep')).toEqual(new Map([['keep', 1]]));
+  });
+});

--- a/helpers/map/filter.ts
+++ b/helpers/map/filter.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Creates a new Map containing only the entries for which the predicate returns true.
+ * @param map - The Map to filter
+ * @param predicate - Function invoked with (value, key) — return true to keep the entry
+ * @returns A new Map with only the matching entries
+ * @example
+ * filter(new Map([['a', 1], ['b', 2], ['c', 3]]), value => value % 2 === 0)
+ * // => Map(1) { 'b' => 2 }
+ * @since next
+ */
+export function filter<K, V>(
+  map: ReadonlyMap<K, V>,
+  predicate: (value: V, key: K) => boolean,
+): Map<K, V> {
+  const result = new Map<K, V>();
+  for (const [key, value] of map) {
+    if (predicate(value, key)) {
+      result.set(key, value);
+    }
+  }
+  return result;
+}

--- a/helpers/map/findKey.example.ts
+++ b/helpers/map/findKey.example.ts
@@ -1,0 +1,35 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { findKey } from './findKey';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'findKey',
+  category: 'map',
+  examples: [
+    {
+      title: 'Find the key of the first matching entry',
+      description: 'Searches in insertion order and returns the key of the first match.',
+      code: `findKey(new Map([['a', 1], ['b', 2]]), value => value > 1)
+// => 'b'`,
+      assert: () => {
+        if (findKey(new Map([['a', 1], ['b', 2]]), (v) => v > 1) !== 'b') throw new Error('Expected "b"');
+      },
+    },
+    {
+      title: 'No match',
+      description: 'Returns undefined when nothing satisfies the predicate.',
+      code: `findKey(new Map([['a', 1]]), value => value > 10)
+// => undefined`,
+      assert: () => {
+        if (findKey(new Map([['a', 1]]), (v) => v > 10) !== undefined) throw new Error('Expected undefined');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/map/findKey.spec.ts
+++ b/helpers/map/findKey.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { findKey } from './findKey';
+
+describe('findKey — property-based', () => {
+  it('the returned key, when present, maps to a value that matches', () => {
+    fc.assert(
+      fc.property(fc.array(fc.tuple(fc.string(), fc.integer())), (entries) => {
+        const map = new Map(entries);
+        const key = findKey(map, (v) => v > 0);
+        if (key !== undefined) {
+          expect(map.get(key)! > 0).toBe(true);
+        }
+      }),
+    );
+  });
+});
+
+describe('findKey — contract', () => {
+  it('empty map returns undefined', () => {
+    expect(findKey(new Map(), () => true)).toBeUndefined();
+  });
+});

--- a/helpers/map/findKey.test.ts
+++ b/helpers/map/findKey.test.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { findKey } from './findKey';
+
+describe('findKey', () => {
+  it('returns the key of the first matching entry', () => {
+    expect(findKey(new Map([['a', 1], ['b', 2], ['c', 3]]), (v) => v > 1)).toBe('b');
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(findKey(new Map([['a', 1]]), (v) => v > 10)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty map', () => {
+    expect(findKey(new Map(), () => true)).toBeUndefined();
+  });
+});

--- a/helpers/map/findKey.ts
+++ b/helpers/map/findKey.ts
@@ -1,0 +1,25 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Returns the first key of a Map whose entry satisfies the predicate, in insertion order.
+ * @param map - The Map to search
+ * @param predicate - Function invoked with (value, key)
+ * @returns The matching key, or `undefined` if none matches
+ * @example
+ * findKey(new Map([['a', 1], ['b', 2]]), value => value > 1)
+ * // => 'b'
+ * @since next
+ */
+export function findKey<K, V>(
+  map: ReadonlyMap<K, V>,
+  predicate: (value: V, key: K) => boolean,
+): K | undefined {
+  for (const [key, value] of map) {
+    if (predicate(value, key)) return key;
+  }
+  return undefined;
+}

--- a/helpers/map/findValue.example.ts
+++ b/helpers/map/findValue.example.ts
@@ -1,0 +1,35 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { findValue } from './findValue';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'findValue',
+  category: 'map',
+  examples: [
+    {
+      title: 'Find the first matching value',
+      description: 'Searches in insertion order and returns the value of the first match.',
+      code: `findValue(new Map([['a', 1], ['b', 2]]), value => value > 1)
+// => 2`,
+      assert: () => {
+        if (findValue(new Map([['a', 1], ['b', 2]]), (v) => v > 1) !== 2) throw new Error('Expected 2');
+      },
+    },
+    {
+      title: 'No match',
+      description: 'Returns undefined when nothing satisfies the predicate.',
+      code: `findValue(new Map([['a', 1]]), value => value > 10)
+// => undefined`,
+      assert: () => {
+        if (findValue(new Map([['a', 1]]), (v) => v > 10) !== undefined) throw new Error('Expected undefined');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/map/findValue.spec.ts
+++ b/helpers/map/findValue.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { findValue } from './findValue';
+
+describe('findValue — property-based', () => {
+  it('the returned value, when present, satisfies the predicate', () => {
+    fc.assert(
+      fc.property(fc.array(fc.tuple(fc.string(), fc.integer())), (entries) => {
+        const map = new Map(entries);
+        const value = findValue(map, (v) => v > 0);
+        if (value !== undefined) {
+          expect(value > 0).toBe(true);
+        }
+      }),
+    );
+  });
+});
+
+describe('findValue — contract', () => {
+  it('empty map returns undefined', () => {
+    expect(findValue(new Map(), () => true)).toBeUndefined();
+  });
+});

--- a/helpers/map/findValue.test.ts
+++ b/helpers/map/findValue.test.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { findValue } from './findValue';
+
+describe('findValue', () => {
+  it('returns the value of the first matching entry', () => {
+    expect(findValue(new Map([['a', 1], ['b', 2], ['c', 3]]), (v) => v > 1)).toBe(2);
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(findValue(new Map([['a', 1]]), (v) => v > 10)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty map', () => {
+    expect(findValue(new Map(), () => true)).toBeUndefined();
+  });
+});

--- a/helpers/map/findValue.ts
+++ b/helpers/map/findValue.ts
@@ -1,0 +1,25 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Returns the first value of a Map whose entry satisfies the predicate, in insertion order.
+ * @param map - The Map to search
+ * @param predicate - Function invoked with (value, key)
+ * @returns The matching value, or `undefined` if none matches
+ * @example
+ * findValue(new Map([['a', 1], ['b', 2]]), value => value > 1)
+ * // => 2
+ * @since next
+ */
+export function findValue<K, V>(
+  map: ReadonlyMap<K, V>,
+  predicate: (value: V, key: K) => boolean,
+): V | undefined {
+  for (const [key, value] of map) {
+    if (predicate(value, key)) return value;
+  }
+  return undefined;
+}

--- a/helpers/map/hasValue.example.ts
+++ b/helpers/map/hasValue.example.ts
@@ -1,0 +1,35 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { hasValue } from './hasValue';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'hasValue',
+  category: 'map',
+  examples: [
+    {
+      title: 'Check whether a value exists in a Map',
+      description: "Unlike Map.prototype.has (which checks keys), this checks values.",
+      code: `hasValue(new Map([['a', 1], ['b', 2]]), 2)
+// => true`,
+      assert: () => {
+        if (!hasValue(new Map([['a', 1], ['b', 2]]), 2)) throw new Error('Expected true');
+      },
+    },
+    {
+      title: 'Value absent',
+      description: 'Returns false when no entry has that value.',
+      code: `hasValue(new Map([['a', 1]]), 99)
+// => false`,
+      assert: () => {
+        if (hasValue(new Map([['a', 1]]), 99)) throw new Error('Expected false');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/map/hasValue.spec.ts
+++ b/helpers/map/hasValue.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { hasValue } from './hasValue';
+
+describe('hasValue — property-based', () => {
+  it('matches Array.from(map.values()).includes(...)', () => {
+    fc.assert(
+      fc.property(fc.array(fc.tuple(fc.string(), fc.integer())), fc.integer(), (entries, needle) => {
+        const map = new Map(entries);
+        expect(hasValue(map, needle)).toBe([...map.values()].includes(needle));
+      }),
+    );
+  });
+});
+
+describe('hasValue — contract', () => {
+  it('empty map never has any value', () => {
+    expect(hasValue(new Map(), 'anything')).toBe(false);
+  });
+});

--- a/helpers/map/hasValue.test.ts
+++ b/helpers/map/hasValue.test.ts
@@ -1,0 +1,31 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { hasValue } from './hasValue';
+
+describe('hasValue', () => {
+  it('returns true when the value is present', () => {
+    expect(hasValue(new Map([['a', 1], ['b', 2]]), 2)).toBe(true);
+  });
+
+  it('returns false when the value is absent', () => {
+    expect(hasValue(new Map([['a', 1]]), 99)).toBe(false);
+  });
+
+  it('returns false for an empty map', () => {
+    expect(hasValue(new Map(), 1)).toBe(false);
+  });
+
+  it('matches NaN to NaN', () => {
+    expect(hasValue(new Map([['a', Number.NaN]]), Number.NaN)).toBe(true);
+  });
+
+  it('does not consider keys, only values', () => {
+    const map = new Map([['target', 'other-value']]);
+    expect(hasValue(map, 'target')).toBe(false);
+  });
+});

--- a/helpers/map/hasValue.ts
+++ b/helpers/map/hasValue.ts
@@ -1,0 +1,23 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Checks whether a value exists anywhere in a Map (`Map.prototype.has` checks keys, not values).
+ * Uses `Object.is`-style equality (via `===`, with `NaN` matching `NaN`).
+ * @param map - The Map to search
+ * @param value - The value to look for
+ * @returns `true` if the value is found in at least one entry
+ * @example
+ * hasValue(new Map([['a', 1], ['b', 2]]), 2)
+ * // => true
+ * @since next
+ */
+export function hasValue<K, V>(map: ReadonlyMap<K, V>, value: V): boolean {
+  for (const v of map.values()) {
+    if (Object.is(v, value)) return true;
+  }
+  return false;
+}

--- a/helpers/map/mapKeys.example.ts
+++ b/helpers/map/mapKeys.example.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { mapKeys } from './mapKeys';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'mapKeys',
+  category: 'map',
+  examples: [
+    {
+      title: 'Uppercase every key',
+      description: 'Creates a new Map with transformed keys and unchanged values.',
+      code: `mapKeys(new Map([['a', 1], ['b', 2]]), key => key.toUpperCase())
+// => Map(2) { 'A' => 1, 'B' => 2 }`,
+      assert: () => {
+        const result = mapKeys(new Map([['a', 1], ['b', 2]]), (key) => key.toUpperCase());
+        if (result.get('A') !== 1 || result.get('B') !== 2) throw new Error('Unexpected result');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/map/mapKeys.spec.ts
+++ b/helpers/map/mapKeys.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { mapKeys } from './mapKeys';
+
+describe('mapKeys — property-based', () => {
+  it('never produces more entries than the input (collisions can only shrink it)', () => {
+    fc.assert(
+      fc.property(fc.array(fc.tuple(fc.string(), fc.integer())), (entries) => {
+        const map = new Map(entries);
+        const result = mapKeys(map, (key) => key.length);
+        expect(result.size).toBeLessThanOrEqual(map.size);
+      }),
+    );
+  });
+
+  it('identity transform preserves the map', () => {
+    fc.assert(
+      fc.property(fc.array(fc.tuple(fc.string(), fc.integer())), (entries) => {
+        const map = new Map(entries);
+        expect(mapKeys(map, (key) => key)).toEqual(map);
+      }),
+    );
+  });
+});
+
+describe('mapKeys — contract', () => {
+  it('empty map returns an empty map', () => {
+    expect(mapKeys(new Map(), (k: string) => k)).toEqual(new Map());
+  });
+});

--- a/helpers/map/mapKeys.test.ts
+++ b/helpers/map/mapKeys.test.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mapKeys } from './mapKeys';
+
+describe('mapKeys', () => {
+  it('transforms every key, keeping values unchanged', () => {
+    const map = new Map([['a', 1], ['b', 2]]);
+    expect(mapKeys(map, (key) => key.toUpperCase())).toEqual(new Map([['A', 1], ['B', 2]]));
+  });
+
+  it('passes the value to the transform function', () => {
+    const map = new Map([['a', 1], ['b', 2]]);
+    expect(mapKeys(map, (key, value) => `${key}${value}`)).toEqual(new Map([['a1', 1], ['b2', 2]]));
+  });
+
+  it('later entry wins when two keys collide after transform', () => {
+    const map = new Map([['a', 1], ['A', 2]]);
+    expect(mapKeys(map, (key) => key.toLowerCase())).toEqual(new Map([['a', 2]]));
+  });
+
+  it('returns an empty map for an empty input', () => {
+    expect(mapKeys(new Map(), (k: string) => k)).toEqual(new Map());
+  });
+});

--- a/helpers/map/mapKeys.ts
+++ b/helpers/map/mapKeys.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Creates a new Map with the same values but with each key transformed by a function.
+ * If two entries derive the same new key, the later one (in insertion order) wins.
+ * @param map - The Map to transform
+ * @param fn - Function invoked with (key, value) that returns the new key
+ * @returns A new Map with transformed keys
+ * @example
+ * mapKeys(new Map([['a', 1], ['b', 2]]), key => key.toUpperCase())
+ * // => Map(2) { 'A' => 1, 'B' => 2 }
+ * @since next
+ */
+export function mapKeys<K, V, R>(
+  map: ReadonlyMap<K, V>,
+  fn: (key: K, value: V) => R,
+): Map<R, V> {
+  const result = new Map<R, V>();
+  for (const [key, value] of map) {
+    result.set(fn(key, value), value);
+  }
+  return result;
+}

--- a/helpers/map/mapValues.example.ts
+++ b/helpers/map/mapValues.example.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { mapValues } from './mapValues';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'mapValues',
+  category: 'map',
+  examples: [
+    {
+      title: 'Scale every value',
+      description: 'Creates a new Map with transformed values and unchanged keys.',
+      code: `mapValues(new Map([['a', 1], ['b', 2]]), value => value * 10)
+// => Map(2) { 'a' => 10, 'b' => 20 }`,
+      assert: () => {
+        const result = mapValues(new Map([['a', 1], ['b', 2]]), (value) => value * 10);
+        if (result.get('a') !== 10 || result.get('b') !== 20) throw new Error('Unexpected result');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/map/mapValues.spec.ts
+++ b/helpers/map/mapValues.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { mapValues } from './mapValues';
+
+describe('mapValues — property-based', () => {
+  it('never changes the set of keys', () => {
+    fc.assert(
+      fc.property(fc.array(fc.tuple(fc.string(), fc.integer())), (entries) => {
+        const map = new Map(entries);
+        const result = mapValues(map, (v) => v * 2);
+        expect([...result.keys()].sort()).toEqual([...map.keys()].sort());
+      }),
+    );
+  });
+
+  it('identity transform preserves the map', () => {
+    fc.assert(
+      fc.property(fc.array(fc.tuple(fc.string(), fc.integer())), (entries) => {
+        const map = new Map(entries);
+        expect(mapValues(map, (v) => v)).toEqual(map);
+      }),
+    );
+  });
+});
+
+describe('mapValues — contract', () => {
+  it('empty map returns an empty map', () => {
+    expect(mapValues(new Map(), (v: number) => v)).toEqual(new Map());
+  });
+});

--- a/helpers/map/mapValues.test.ts
+++ b/helpers/map/mapValues.test.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mapValues } from './mapValues';
+
+describe('mapValues', () => {
+  it('transforms every value, keeping keys unchanged', () => {
+    const map = new Map([['a', 1], ['b', 2]]);
+    expect(mapValues(map, (value) => value * 10)).toEqual(new Map([['a', 10], ['b', 20]]));
+  });
+
+  it('passes the key to the transform function', () => {
+    const map = new Map([['a', 1], ['b', 2]]);
+    expect(mapValues(map, (value, key) => `${key}${value}`)).toEqual(new Map([['a', 'a1'], ['b', 'b2']]));
+  });
+
+  it('preserves key order', () => {
+    const map = new Map([['z', 1], ['a', 2]]);
+    expect([...mapValues(map, (v) => v).keys()]).toEqual(['z', 'a']);
+  });
+
+  it('returns an empty map for an empty input', () => {
+    expect(mapValues(new Map(), (v: number) => v)).toEqual(new Map());
+  });
+});

--- a/helpers/map/mapValues.ts
+++ b/helpers/map/mapValues.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Creates a new Map with the same keys but with each value transformed by a function.
+ * @param map - The Map to transform
+ * @param fn - Function invoked with (value, key) that returns the new value
+ * @returns A new Map with transformed values
+ * @example
+ * mapValues(new Map([['a', 1], ['b', 2]]), value => value * 10)
+ * // => Map(2) { 'a' => 10, 'b' => 20 }
+ * @since next
+ */
+export function mapValues<K, V, R>(
+  map: ReadonlyMap<K, V>,
+  fn: (value: V, key: K) => R,
+): Map<K, R> {
+  const result = new Map<K, R>();
+  for (const [key, value] of map) {
+    result.set(key, fn(value, key));
+  }
+  return result;
+}

--- a/helpers/map/reduce.example.ts
+++ b/helpers/map/reduce.example.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { reduce } from './reduce';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'reduce',
+  category: 'map',
+  examples: [
+    {
+      title: 'Sum all values',
+      description: 'Reduces a Map of numbers to their total.',
+      code: `reduce(new Map([['a', 1], ['b', 2], ['c', 3]]), (acc, value) => acc + value, 0)
+// => 6`,
+      assert: () => {
+        const total = reduce(new Map([['a', 1], ['b', 2], ['c', 3]]), (acc, value) => acc + value, 0);
+        if (total !== 6) throw new Error(`Expected 6, got ${total}`);
+      },
+    },
+    {
+      title: 'Build an array of keys',
+      description: 'Reduce can produce a completely different shape than the map values.',
+      code: `reduce(new Map([['a', 1], ['b', 2]]), (acc: string[], _v, key) => [...acc, key], [])
+// => ['a', 'b']`,
+      assert: () => {
+        const keys = reduce(new Map([['a', 1], ['b', 2]]), (acc: string[], _v, key) => [...acc, key], []);
+        if (keys.join(',') !== 'a,b') throw new Error('Unexpected keys order');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/map/reduce.spec.ts
+++ b/helpers/map/reduce.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { reduce } from './reduce';
+
+describe('reduce — property-based', () => {
+  it('summing values equals summing Array.from(map.values())', () => {
+    fc.assert(
+      fc.property(fc.array(fc.tuple(fc.string(), fc.integer())), (entries) => {
+        const map = new Map(entries);
+        const viaReduce = reduce(map, (acc, v) => acc + v, 0);
+        const viaArray = [...map.values()].reduce((acc, v) => acc + v, 0);
+        expect(viaReduce).toBe(viaArray);
+      }),
+    );
+  });
+});
+
+describe('reduce — contract', () => {
+  it('empty map returns the initial value unchanged', () => {
+    expect(reduce(new Map(), () => { throw new Error('never called'); }, 'seed')).toBe('seed');
+  });
+});

--- a/helpers/map/reduce.test.ts
+++ b/helpers/map/reduce.test.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { reduce } from './reduce';
+
+describe('reduce', () => {
+  it('accumulates values across entries', () => {
+    const map = new Map([['a', 1], ['b', 2], ['c', 3]]);
+    expect(reduce(map, (acc, value) => acc + value, 0)).toBe(6);
+  });
+
+  it('passes the key to the reducer', () => {
+    const map = new Map([['a', 1], ['b', 2]]);
+    expect(reduce(map, (acc, value, key) => acc + key + value, '')).toBe('a1b2');
+  });
+
+  it('returns the initial value for an empty map', () => {
+    expect(reduce(new Map(), (acc: number, v: number) => acc + v, 42)).toBe(42);
+  });
+
+  it('can build a different type than the map values', () => {
+    const map = new Map([['a', 1], ['b', 2]]);
+    expect(reduce(map, (acc: string[], _v, key) => [...acc, key], [])).toEqual(['a', 'b']);
+  });
+});

--- a/helpers/map/reduce.ts
+++ b/helpers/map/reduce.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Reduces a Map to a single value by applying a function to each entry, in insertion order.
+ * @param map - The Map to reduce
+ * @param fn - Function invoked with (accumulator, value, key)
+ * @param initial - Initial accumulator value
+ * @returns The final accumulator value
+ * @example
+ * reduce(new Map([['a', 1], ['b', 2]]), (acc, value) => acc + value, 0)
+ * // => 3
+ * @since next
+ */
+export function reduce<K, V, R>(
+  map: ReadonlyMap<K, V>,
+  fn: (accumulator: R, value: V, key: K) => R,
+  initial: R,
+): R {
+  let accumulator = initial;
+  for (const [key, value] of map) {
+    accumulator = fn(accumulator, value, key);
+  }
+  return accumulator;
+}

--- a/helpers/map/some.example.ts
+++ b/helpers/map/some.example.ts
@@ -1,0 +1,35 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { some } from './some';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'some',
+  category: 'map',
+  examples: [
+    {
+      title: 'Check if any value exceeds a threshold',
+      description: 'Returns true as soon as one entry satisfies the predicate.',
+      code: `some(new Map([['a', 1], ['b', 2]]), value => value > 1)
+// => true`,
+      assert: () => {
+        if (!some(new Map([['a', 1], ['b', 2]]), (v) => v > 1)) throw new Error('Expected true');
+      },
+    },
+    {
+      title: 'Empty map',
+      description: 'Always returns false for an empty map.',
+      code: `some(new Map(), () => true)
+// => false`,
+      assert: () => {
+        if (some(new Map(), () => true)) throw new Error('Expected false');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/map/some.spec.ts
+++ b/helpers/map/some.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { some } from './some';
+
+describe('some — property-based', () => {
+  it('matches Array.from(map.values()).some(...)', () => {
+    fc.assert(
+      fc.property(fc.array(fc.tuple(fc.string(), fc.integer())), (entries) => {
+        const map = new Map(entries);
+        expect(some(map, (v) => v > 0)).toBe([...map.values()].some((v) => v > 0));
+      }),
+    );
+  });
+});
+
+describe('some — contract', () => {
+  it('empty map is always false', () => {
+    expect(some(new Map(), () => true)).toBe(false);
+  });
+});

--- a/helpers/map/some.test.ts
+++ b/helpers/map/some.test.ts
@@ -1,0 +1,31 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { some } from './some';
+
+describe('some', () => {
+  it('returns true when at least one entry matches', () => {
+    expect(some(new Map([['a', 1], ['b', 2]]), (v) => v > 1)).toBe(true);
+  });
+
+  it('returns false when no entry matches', () => {
+    expect(some(new Map([['a', 1], ['b', 2]]), (v) => v > 10)).toBe(false);
+  });
+
+  it('returns false for an empty map', () => {
+    expect(some(new Map(), () => true)).toBe(false);
+  });
+
+  it('short-circuits after the first match', () => {
+    let calls = 0;
+    some(new Map([['a', 1], ['b', 2], ['c', 3]]), (v) => {
+      calls++;
+      return v === 1;
+    });
+    expect(calls).toBe(1);
+  });
+});

--- a/helpers/map/some.ts
+++ b/helpers/map/some.ts
@@ -1,0 +1,25 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Checks if at least one entry of a Map satisfies the predicate. Short-circuits on the first match.
+ * @param map - The Map to check
+ * @param predicate - Function invoked with (value, key)
+ * @returns `true` if at least one entry matches, `false` otherwise (including for an empty map)
+ * @example
+ * some(new Map([['a', 1], ['b', 2]]), value => value > 1)
+ * // => true
+ * @since next
+ */
+export function some<K, V>(
+  map: ReadonlyMap<K, V>,
+  predicate: (value: V, key: K) => boolean,
+): boolean {
+  for (const [key, value] of map) {
+    if (predicate(value, key)) return true;
+  }
+  return false;
+}

--- a/helpers/map/toMapByKey.example.ts
+++ b/helpers/map/toMapByKey.example.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { toMapByKey } from './toMapByKey';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'toMapByKey',
+  category: 'map',
+  examples: [
+    {
+      title: 'Index an array of records by id',
+      description: 'Builds a Map keyed by a derived value, for O(1) lookup by that key.',
+      code: `toMapByKey([{ id: 'a', n: 1 }, { id: 'b', n: 2 }], item => item.id)
+// => Map(2) { 'a' => {...}, 'b' => {...} }`,
+      assert: () => {
+        const map = toMapByKey([{ id: 'a', n: 1 }, { id: 'b', n: 2 }], (item) => item.id);
+        if (map.get('b')?.n !== 2) throw new Error('Unexpected lookup result');
+      },
+    },
+    {
+      title: 'Last item wins on collision',
+      description: 'When two items derive the same key, the later one overwrites the earlier one.',
+      code: `toMapByKey([{ id: 'a', n: 1 }, { id: 'a', n: 2 }], item => item.id).get('a')
+// => { id: 'a', n: 2 }`,
+      assert: () => {
+        const map = toMapByKey([{ id: 'a', n: 1 }, { id: 'a', n: 2 }], (item) => item.id);
+        if (map.get('a')?.n !== 2) throw new Error('Expected the later item to win');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/map/toMapByKey.spec.ts
+++ b/helpers/map/toMapByKey.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { toMapByKey } from './toMapByKey';
+
+describe('toMapByKey — property-based', () => {
+  it('result size never exceeds the input length', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer()), (items) => {
+        const result = toMapByKey(items, (n) => n % 5);
+        expect(result.size).toBeLessThanOrEqual(items.length);
+      }),
+    );
+  });
+
+  it('every value in the result was present in the input', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer(), { minLength: 1 }), (items) => {
+        const result = toMapByKey(items, (n) => n);
+        for (const value of result.values()) {
+          expect(items).toContain(value);
+        }
+      }),
+    );
+  });
+});
+
+describe('toMapByKey — contract', () => {
+  it('empty input returns an empty map', () => {
+    expect(toMapByKey([], (x: never) => x)).toEqual(new Map());
+  });
+});

--- a/helpers/map/toMapByKey.test.ts
+++ b/helpers/map/toMapByKey.test.ts
@@ -1,0 +1,34 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { toMapByKey } from './toMapByKey';
+
+describe('toMapByKey', () => {
+  it('indexes items by a derived key', () => {
+    const items = [{ id: 'a', n: 1 }, { id: 'b', n: 2 }];
+    expect(toMapByKey(items, (item) => item.id)).toEqual(
+      new Map([['a', { id: 'a', n: 1 }], ['b', { id: 'b', n: 2 }]]),
+    );
+  });
+
+  it('last item wins on key collision', () => {
+    const items = [{ id: 'a', n: 1 }, { id: 'a', n: 2 }];
+    expect(toMapByKey(items, (item) => item.id).get('a')).toEqual({ id: 'a', n: 2 });
+  });
+
+  it('returns an empty map for an empty input', () => {
+    expect(toMapByKey([], (x: never) => x)).toEqual(new Map());
+  });
+
+  it('works with any iterable, not just arrays', () => {
+    function* gen() {
+      yield 1;
+      yield 2;
+    }
+    expect(toMapByKey(gen(), (n) => n * 10)).toEqual(new Map([[10, 1], [20, 2]]));
+  });
+});

--- a/helpers/map/toMapByKey.ts
+++ b/helpers/map/toMapByKey.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Builds a Map from an iterable of items, keyed by a derived key. When two items derive the
+ * same key, the later item wins (last-write-wins, matching `Map.prototype.set` semantics).
+ *
+ * Named `toMapByKey`, not `keyBy` (lodash's name for the same idea) — lodash's `_.keyBy`
+ * returns a plain object, not a `Map`; the `to<Type>` prefix (matching `toSorted`/`toReversed`)
+ * makes the actual return type unambiguous.
+ * @param items - The items to index
+ * @param fn - Function deriving the key for each item
+ * @returns A Map from derived key to item
+ * @example
+ * toMapByKey([{ id: 'a', n: 1 }, { id: 'b', n: 2 }], item => item.id)
+ * // => Map(2) { 'a' => { id: 'a', n: 1 }, 'b' => { id: 'b', n: 2 } }
+ * @since next
+ */
+export function toMapByKey<T, K>(items: Iterable<T>, fn: (item: T) => K): Map<K, T> {
+  const result = new Map<K, T>();
+  for (const item of items) {
+    result.set(fn(item), item);
+  }
+  return result;
+}

--- a/helpers/object/camelCaseKeys.example.ts
+++ b/helpers/object/camelCaseKeys.example.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { camelCaseKeys } from './camelCaseKeys';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'camelCaseKeys',
+  category: 'object',
+  examples: [
+    {
+      title: 'Convert a snake_case API response',
+      description: 'Recursively converts every key, including nested objects, to camelCase.',
+      code: `camelCaseKeys({ user_name: 'Alice', home_address: { zip_code: '12345' } })
+// => { userName: 'Alice', homeAddress: { zipCode: '12345' } }`,
+      assert: () => {
+        const result = camelCaseKeys({ user_name: 'Alice', home_address: { zip_code: '12345' } });
+        if (JSON.stringify(result) !== JSON.stringify({ userName: 'Alice', homeAddress: { zipCode: '12345' } })) {
+          throw new Error('Unexpected result');
+        }
+      },
+    },
+    {
+      title: 'Arrays of objects are walked too',
+      description: 'Each object inside an array gets its keys converted.',
+      code: `camelCaseKeys({ user_list: [{ first_name: 'A' }] })
+// => { userList: [{ firstName: 'A' }] }`,
+      assert: () => {
+        const result = camelCaseKeys({ user_list: [{ first_name: 'A' }] });
+        if (JSON.stringify(result) !== JSON.stringify({ userList: [{ firstName: 'A' }] })) {
+          throw new Error('Unexpected result');
+        }
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/object/camelCaseKeys.spec.ts
+++ b/helpers/object/camelCaseKeys.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { camelCaseKeys } from './camelCaseKeys';
+
+describe('camelCaseKeys — property-based', () => {
+  it('never produces more keys than the input (collisions can only shrink it)', () => {
+    fc.assert(
+      fc.property(fc.dictionary(fc.string({ minLength: 1 }).filter((s) => /[a-z]/i.test(s)), fc.integer()), (obj) => {
+        const result = camelCaseKeys(obj);
+        expect(Object.keys(result).length).toBeLessThanOrEqual(Object.keys(obj).length);
+      }),
+    );
+  });
+
+  it('is idempotent on already-camelCase keys', () => {
+    fc.assert(
+      fc.property(fc.dictionary(fc.constantFrom('fooBar', 'baz', 'quxQuux'), fc.integer()), (obj) => {
+        expect(camelCaseKeys(obj)).toEqual(obj);
+      }),
+    );
+  });
+});
+
+describe('camelCaseKeys — contract', () => {
+  it('empty object stays empty', () => {
+    expect(camelCaseKeys({})).toEqual({});
+  });
+
+  it('primitives pass through unchanged', () => {
+    expect(camelCaseKeys(42)).toBe(42);
+    expect(camelCaseKeys('str')).toBe('str');
+    expect(camelCaseKeys(null)).toBe(null);
+  });
+});

--- a/helpers/object/camelCaseKeys.test.ts
+++ b/helpers/object/camelCaseKeys.test.ts
@@ -1,0 +1,66 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { camelCaseKeys } from './camelCaseKeys';
+
+describe('camelCaseKeys', () => {
+  it('converts snake_case keys to camelCase', () => {
+    expect(camelCaseKeys({ user_name: 'Alice' })).toEqual({ userName: 'Alice' });
+  });
+
+  it('converts kebab-case keys to camelCase', () => {
+    expect(camelCaseKeys({ 'user-name': 'Alice' })).toEqual({ userName: 'Alice' });
+  });
+
+  it('recurses into nested plain objects', () => {
+    expect(camelCaseKeys({ home_address: { zip_code: '12345' } })).toEqual({
+      homeAddress: { zipCode: '12345' },
+    });
+  });
+
+  it('recurses into arrays of objects', () => {
+    expect(camelCaseKeys({ user_list: [{ first_name: 'A' }, { first_name: 'B' }] })).toEqual({
+      userList: [{ firstName: 'A' }, { firstName: 'B' }],
+    });
+  });
+
+  it('leaves already-camelCase keys unchanged', () => {
+    expect(camelCaseKeys({ userName: 'Alice' })).toEqual({ userName: 'Alice' });
+  });
+
+  it('does not descend into non-plain-object values', () => {
+    const date = new Date('2026-01-01');
+    expect(camelCaseKeys({ created_at: date })).toEqual({ createdAt: date });
+  });
+
+  it('handles an empty object', () => {
+    expect(camelCaseKeys({})).toEqual({});
+  });
+
+  it('collapses a key with no word characters to an empty string (matches camelCase() directly)', () => {
+    expect(camelCaseKeys({ '___': 'value' })).toEqual({ '': 'value' });
+  });
+
+  it('does not mutate the input', () => {
+    const input = { user_name: 'Alice' };
+    camelCaseKeys(input);
+    expect(input).toEqual({ user_name: 'Alice' });
+  });
+
+  it('skips a dangerous key (constructor)', () => {
+    expect(camelCaseKeys({ constructor: 'x', a: 1 })).toEqual({ a: 1 });
+  });
+
+  it('skips a dangerous key (prototype)', () => {
+    expect(camelCaseKeys({ prototype: 'x', a: 1 })).toEqual({ a: 1 });
+  });
+
+  it('sanitizes a literal __proto__ key to "proto" rather than needing to skip it', () => {
+    const obj = JSON.parse('{"__proto__": "x", "a": 1}') as Record<string, unknown>;
+    expect(camelCaseKeys(obj)).toEqual({ proto: 'x', a: 1 });
+  });
+});

--- a/helpers/object/camelCaseKeys.ts
+++ b/helpers/object/camelCaseKeys.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { camelCase } from '../string/camelCase.js';
+import { mapDeep } from './mapDeep.js';
+
+/**
+ * Recursively transforms every key of a plain object (including keys nested inside arrays and
+ * nested objects) to camelCase. Handles snake_case, kebab-case, PascalCase, and space-separated
+ * keys. Non-plain-object values (arrays' items aside) — `Date`, `Map`, `Set`, class instances,
+ * primitives — are left untouched, only their position is walked into. An entry whose
+ * transformed key is a prototype-polluting string (`__proto__`, `constructor`, `prototype`) is
+ * silently skipped, same as the rest of `@helpers4/object`.
+ * @param value - The object (or array of objects) to transform
+ * @returns A new value with every plain-object key converted to camelCase
+ * @example
+ * camelCaseKeys({ user_name: 'Alice', home_address: { zip_code: '12345' } })
+ * // => { userName: 'Alice', homeAddress: { zipCode: '12345' } }
+ * @since next
+ */
+export function camelCaseKeys<T>(value: T): T {
+  return mapDeep(value, undefined, camelCase);
+}

--- a/helpers/object/get.ts
+++ b/helpers/object/get.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+import { walkPropertyPath } from '../_shared/_walkPropertyPath.js';
 import { parsePropertyPath } from './parsePropertyPath.js';
 import type { DeepGet, ParsePath } from './_types.js';
 
@@ -50,14 +51,6 @@ export function get<T extends object, const P extends string | readonly Property
 export function get(obj: unknown, path: string | readonly PropertyKey[], defaultValue?: unknown): unknown {
   if (obj == null) return defaultValue;
   const keys: readonly PropertyKey[] = typeof path === 'string' ? parsePropertyPath(path) : path;
-  let result: unknown = obj;
-
-  for (const key of keys) {
-    if (result == null || typeof result !== 'object') {
-      return defaultValue;
-    }
-    result = (result as Record<PropertyKey, unknown>)[key];
-  }
-
+  const result = walkPropertyPath(obj, keys);
   return result !== undefined ? result : defaultValue;
 }

--- a/helpers/object/kebabCaseKeys.example.ts
+++ b/helpers/object/kebabCaseKeys.example.ts
@@ -1,0 +1,32 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { kebabCaseKeys } from './kebabCaseKeys';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'kebabCaseKeys',
+  category: 'object',
+  examples: [
+    {
+      title: 'Convert object keys for a kebab-case config format',
+      description: 'Recursively converts every key, including nested objects, to kebab-case.',
+      code: `kebabCaseKeys({ userName: 'Alice', homeAddress: { zipCode: '12345' } })
+// => { 'user-name': 'Alice', 'home-address': { 'zip-code': '12345' } }`,
+      assert: () => {
+        const result = kebabCaseKeys({ userName: 'Alice', homeAddress: { zipCode: '12345' } });
+        if (
+          JSON.stringify(result) !==
+          JSON.stringify({ 'user-name': 'Alice', 'home-address': { 'zip-code': '12345' } })
+        ) {
+          throw new Error('Unexpected result');
+        }
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/object/kebabCaseKeys.spec.ts
+++ b/helpers/object/kebabCaseKeys.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { kebabCaseKeys } from './kebabCaseKeys';
+
+describe('kebabCaseKeys — property-based', () => {
+  it('never produces more keys than the input (collisions can only shrink it)', () => {
+    fc.assert(
+      fc.property(fc.dictionary(fc.string({ minLength: 1 }).filter((s) => /[a-z]/i.test(s)), fc.integer()), (obj) => {
+        const result = kebabCaseKeys(obj);
+        expect(Object.keys(result).length).toBeLessThanOrEqual(Object.keys(obj).length);
+      }),
+    );
+  });
+
+  it('is idempotent on already-kebab-case keys', () => {
+    fc.assert(
+      fc.property(fc.dictionary(fc.constantFrom('foo-bar', 'baz', 'qux-quux'), fc.integer()), (obj) => {
+        expect(kebabCaseKeys(obj)).toEqual(obj);
+      }),
+    );
+  });
+});
+
+describe('kebabCaseKeys — contract', () => {
+  it('empty object stays empty', () => {
+    expect(kebabCaseKeys({})).toEqual({});
+  });
+
+  it('primitives pass through unchanged', () => {
+    expect(kebabCaseKeys(42)).toBe(42);
+    expect(kebabCaseKeys(null)).toBe(null);
+  });
+});

--- a/helpers/object/kebabCaseKeys.test.ts
+++ b/helpers/object/kebabCaseKeys.test.ts
@@ -1,0 +1,42 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { kebabCaseKeys } from './kebabCaseKeys';
+
+describe('kebabCaseKeys', () => {
+  it('converts camelCase keys to kebab-case', () => {
+    expect(kebabCaseKeys({ userName: 'Alice' })).toEqual({ 'user-name': 'Alice' });
+  });
+
+  it('converts snake_case keys to kebab-case', () => {
+    expect(kebabCaseKeys({ user_name: 'Alice' })).toEqual({ 'user-name': 'Alice' });
+  });
+
+  it('recurses into nested plain objects', () => {
+    expect(kebabCaseKeys({ homeAddress: { zipCode: '12345' } })).toEqual({
+      'home-address': { 'zip-code': '12345' },
+    });
+  });
+
+  it('recurses into arrays of objects', () => {
+    expect(kebabCaseKeys({ userList: [{ firstName: 'A' }] })).toEqual({
+      'user-list': [{ 'first-name': 'A' }],
+    });
+  });
+
+  it('leaves already-kebab-case keys unchanged', () => {
+    expect(kebabCaseKeys({ 'user-name': 'Alice' })).toEqual({ 'user-name': 'Alice' });
+  });
+
+  it('handles an empty object', () => {
+    expect(kebabCaseKeys({})).toEqual({});
+  });
+
+  it('skips a dangerous key (constructor)', () => {
+    expect(kebabCaseKeys({ constructor: 'x', a: 1 })).toEqual({ a: 1 });
+  });
+});

--- a/helpers/object/kebabCaseKeys.ts
+++ b/helpers/object/kebabCaseKeys.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { kebabCase } from '../string/kebabCase.js';
+import { mapDeep } from './mapDeep.js';
+
+/**
+ * Recursively transforms every key of a plain object (including keys nested inside arrays and
+ * nested objects) to kebab-case. Handles snake_case, camelCase, PascalCase, and space-separated
+ * keys. Non-plain-object values — `Date`, `Map`, `Set`, class instances, primitives — are left
+ * untouched, only their position is walked into. An entry whose transformed key is a
+ * prototype-polluting string (`__proto__`, `constructor`, `prototype`) is silently skipped,
+ * same as the rest of `@helpers4/object`.
+ * @param value - The object (or array of objects) to transform
+ * @returns A new value with every plain-object key converted to kebab-case
+ * @example
+ * kebabCaseKeys({ userName: 'Alice', homeAddress: { zipCode: '12345' } })
+ * // => { 'user-name': 'Alice', 'home-address': { 'zip-code': '12345' } }
+ * @since next
+ */
+export function kebabCaseKeys<T>(value: T): T {
+  return mapDeep(value, undefined, kebabCase);
+}

--- a/helpers/object/mapDeep.example.ts
+++ b/helpers/object/mapDeep.example.ts
@@ -1,0 +1,47 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { mapDeep } from './mapDeep';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'mapDeep',
+  category: 'object',
+  examples: [
+    {
+      title: 'Transform every key, recursively',
+      description: 'Unlike map(), mapDeep() walks into nested objects and arrays of objects.',
+      code: `mapDeep({ a: { b: 1 } }, undefined, key => key.toUpperCase())
+// => { A: { B: 1 } }`,
+      assert: () => {
+        const result = mapDeep({ a: { b: 1 } }, undefined, (key) => key.toUpperCase());
+        if (JSON.stringify(result) !== JSON.stringify({ A: { B: 1 } })) throw new Error('Unexpected result');
+      },
+    },
+    {
+      title: 'Transform every value, recursively',
+      description: 'Values are visited after their own nested content has already been transformed.',
+      code: `mapDeep({ a: { b: 1, c: 2 } }, v => typeof v === 'number' ? v * 10 : v)
+// => { a: { b: 10, c: 20 } }`,
+      assert: () => {
+        const result = mapDeep({ a: { b: 1, c: 2 } }, (v) => (typeof v === 'number' ? v * 10 : v));
+        if (JSON.stringify(result) !== JSON.stringify({ a: { b: 10, c: 20 } })) throw new Error('Unexpected result');
+      },
+    },
+    {
+      title: 'Transform values inside arrays too',
+      description: 'Array elements are visited by mapValue as well, keyed by their stringified index.',
+      code: `mapDeep({ tags: [1, 2, 3] }, v => typeof v === 'number' ? v * 10 : v)
+// => { tags: [10, 20, 30] }`,
+      assert: () => {
+        const result = mapDeep({ tags: [1, 2, 3] }, (v) => (typeof v === 'number' ? v * 10 : v));
+        if (JSON.stringify(result) !== JSON.stringify({ tags: [10, 20, 30] })) throw new Error('Unexpected result');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/object/mapDeep.spec.ts
+++ b/helpers/object/mapDeep.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { UNSAFE_KEYS } from '../_shared/_unsafeKeys';
+import { mapDeep } from './mapDeep';
+
+const safeKey = fc.string({ minLength: 1 }).filter((s) => !UNSAFE_KEYS.has(s));
+
+describe('mapDeep — property-based', () => {
+  it('identity transform preserves the object', () => {
+    fc.assert(
+      fc.property(fc.dictionary(safeKey, fc.integer()), (obj) => {
+        expect(mapDeep(obj)).toEqual(obj);
+      }),
+    );
+  });
+
+  it('never produces more top-level keys than the input (collisions can only shrink it)', () => {
+    fc.assert(
+      fc.property(fc.dictionary(safeKey, fc.integer()), (obj) => {
+        const result = mapDeep(obj, undefined, (k) => k.slice(0, 1)) as Record<string, unknown>;
+        expect(Object.keys(result).length).toBeLessThanOrEqual(Object.keys(obj).length);
+      }),
+    );
+  });
+});
+
+describe('mapDeep — contract', () => {
+  it('empty object stays empty', () => {
+    expect(mapDeep({})).toEqual({});
+  });
+
+  it('primitives pass through unchanged', () => {
+    expect(mapDeep(42)).toBe(42);
+    expect(mapDeep(null)).toBe(null);
+  });
+});

--- a/helpers/object/mapDeep.test.ts
+++ b/helpers/object/mapDeep.test.ts
@@ -1,0 +1,75 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mapDeep } from './mapDeep';
+
+describe('mapDeep', () => {
+  it('transforms values recursively', () => {
+    expect(mapDeep({ a: { b: 1, c: 2 } }, (v) => (typeof v === 'number' ? v * 10 : v))).toEqual({
+      a: { b: 10, c: 20 },
+    });
+  });
+
+  it('transforms keys recursively', () => {
+    expect(mapDeep({ a: { b: 1 } }, undefined, (k) => k.toUpperCase())).toEqual({ A: { B: 1 } });
+  });
+
+  it('transforms both keys and values', () => {
+    expect(
+      mapDeep(
+        { a: { b: 1 } },
+        (v) => (typeof v === 'number' ? v * 10 : v),
+        (k) => k.toUpperCase(),
+      ),
+    ).toEqual({ A: { B: 10 } });
+  });
+
+  it('recurses into arrays of objects', () => {
+    expect(mapDeep({ list: [{ a: 1 }, { a: 2 }] }, undefined, (k) => k.toUpperCase())).toEqual({
+      LIST: [{ A: 1 }, { A: 2 }],
+    });
+  });
+
+  it('transforms primitives that live directly inside an array', () => {
+    expect(mapDeep({ list: [1, 2, 3] }, (v) => (typeof v === 'number' ? v * 10 : v))).toEqual({
+      list: [10, 20, 30],
+    });
+  });
+
+  it('transforms primitives in a bare top-level array', () => {
+    expect(mapDeep([1, 2, 3], (v) => (typeof v === 'number' ? v * 10 : v))).toEqual([10, 20, 30]);
+  });
+
+  it('passes the stringified index as key for array elements', () => {
+    const keys: string[] = [];
+    mapDeep([1, 2], (v, key) => {
+      keys.push(key);
+      return v;
+    });
+    expect(keys).toEqual(['0', '1']);
+  });
+
+  it('leaves Date/Map/Set untouched, only walks into their position', () => {
+    const date = new Date('2026-01-01');
+    expect(mapDeep({ created: date }, undefined, (k) => k.toUpperCase())).toEqual({ CREATED: date });
+  });
+
+  it('defaults to identity when no callbacks are given', () => {
+    const obj = { a: { b: 1 } };
+    expect(mapDeep(obj)).toEqual(obj);
+  });
+
+  it('skips a dangerous mapped key (constructor)', () => {
+    expect(mapDeep({ a: 1 }, undefined, () => 'constructor')).toEqual({});
+  });
+
+  it('does not mutate the input', () => {
+    const input = { a: { b: 1 } };
+    mapDeep(input, (v) => (typeof v === 'number' ? v * 10 : v));
+    expect(input).toEqual({ a: { b: 1 } });
+  });
+});

--- a/helpers/object/mapDeep.ts
+++ b/helpers/object/mapDeep.ts
@@ -1,0 +1,72 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { UNSAFE_KEYS } from '../_shared/_unsafeKeys.js';
+import { isPlainObject } from '../guard/isPlainObject.js';
+
+function transform(
+  value: unknown,
+  mapValue?: (value: unknown, key: string) => unknown,
+  mapKey?: (key: string, value: unknown) => PropertyKey,
+): unknown {
+  if (Array.isArray(value))
+    return value.map((item, index) => {
+      const recursed = transform(item, mapValue, mapKey);
+      return mapValue ? mapValue(recursed, String(index)) : recursed;
+    });
+  if (isPlainObject(value)) {
+    const result: Record<PropertyKey, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      const newKey = mapKey ? mapKey(key, val) : key;
+      if (typeof newKey === 'string' && UNSAFE_KEYS.has(newKey)) continue;
+      const recursed = transform(val, mapValue, mapKey);
+      result[newKey] = mapValue ? mapValue(recursed, key) : recursed;
+    }
+    return result;
+  }
+  return value;
+}
+
+/**
+ * Recursively transforms the keys and/or values of a plain object — the deep counterpart to
+ * {@link map}, which only transforms the top level. Descends into nested plain objects and
+ * arrays of them; `Date`, `Map`, `Set`, class instances, and primitives are left untouched
+ * (only their position is walked into, matching {@link cloneDeep}'s notion of what counts
+ * as a plain-data node worth recursing into).
+ *
+ * Both callbacks are optional and default to identity (no transformation). `mapKey` is called
+ * with the *original* key and value (before any recursive value transform); `mapValue` receives
+ * the already-recursed value. Entries whose mapped key is a prototype-polluting string
+ * (`__proto__`, `constructor`, `prototype`) are silently skipped, same as {@link map}.
+ *
+ * Array elements also go through `mapValue` (with their stringified index as `key`, since
+ * arrays have no property keys of their own) — so values inside a plain array, not just object
+ * properties, get transformed too. `mapKey` is never called for array elements, since there is
+ * no key to rename.
+ *
+ * @param obj - The value to transform (typically an object, or an array of objects)
+ * @param mapValue - Callback called with `(value, key)` for each entry's (already-recursed) value.
+ *   For array elements, `key` is the element's index as a string. Defaults to identity.
+ * @param mapKey - Callback called with `(key, value)` for each object entry. Defaults to identity.
+ * @returns A new value with every plain-object key/value transformed
+ * @example
+ * mapDeep({ a: { b: 1 } }, v => (typeof v === 'number' ? v * 10 : v))
+ * // => { a: { b: 10 } }
+ * @example
+ * mapDeep({ user_name: 'Alice' }, undefined, key => key.toUpperCase())
+ * // => { USER_NAME: 'Alice' }
+ * @example
+ * mapDeep({ tags: [1, 2, 3] }, v => (typeof v === 'number' ? v * 10 : v))
+ * // => { tags: [10, 20, 30] }
+ * @since next
+ */
+export function mapDeep<T>(
+  obj: T,
+  mapValue?: (value: unknown, key: string) => unknown,
+  mapKey?: (key: string, value: unknown) => PropertyKey,
+): T {
+  return transform(obj, mapValue, mapKey) as T;
+}

--- a/helpers/object/pascalCaseKeys.example.ts
+++ b/helpers/object/pascalCaseKeys.example.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { pascalCaseKeys } from './pascalCaseKeys';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'pascalCaseKeys',
+  category: 'object',
+  examples: [
+    {
+      title: 'Convert object keys to PascalCase (e.g. for a C#/JSON.NET consumer)',
+      description: 'Recursively converts every key, including nested objects, to PascalCase.',
+      code: `pascalCaseKeys({ user_name: 'Alice', home_address: { zip_code: '12345' } })
+// => { UserName: 'Alice', HomeAddress: { ZipCode: '12345' } }`,
+      assert: () => {
+        const result = pascalCaseKeys({ user_name: 'Alice', home_address: { zip_code: '12345' } });
+        if (JSON.stringify(result) !== JSON.stringify({ UserName: 'Alice', HomeAddress: { ZipCode: '12345' } })) {
+          throw new Error('Unexpected result');
+        }
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/object/pascalCaseKeys.spec.ts
+++ b/helpers/object/pascalCaseKeys.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { pascalCaseKeys } from './pascalCaseKeys';
+
+describe('pascalCaseKeys — property-based', () => {
+  it('never produces more keys than the input (collisions can only shrink it)', () => {
+    fc.assert(
+      fc.property(fc.dictionary(fc.string({ minLength: 1 }).filter((s) => /[a-z]/i.test(s)), fc.integer()), (obj) => {
+        const result = pascalCaseKeys(obj);
+        expect(Object.keys(result).length).toBeLessThanOrEqual(Object.keys(obj).length);
+      }),
+    );
+  });
+
+  it('is idempotent on already-PascalCase keys', () => {
+    fc.assert(
+      fc.property(fc.dictionary(fc.constantFrom('FooBar', 'Baz', 'QuxQuux'), fc.integer()), (obj) => {
+        expect(pascalCaseKeys(obj)).toEqual(obj);
+      }),
+    );
+  });
+});
+
+describe('pascalCaseKeys — contract', () => {
+  it('empty object stays empty', () => {
+    expect(pascalCaseKeys({})).toEqual({});
+  });
+
+  it('primitives pass through unchanged', () => {
+    expect(pascalCaseKeys(42)).toBe(42);
+    expect(pascalCaseKeys(null)).toBe(null);
+  });
+});

--- a/helpers/object/pascalCaseKeys.test.ts
+++ b/helpers/object/pascalCaseKeys.test.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { pascalCaseKeys } from './pascalCaseKeys';
+
+describe('pascalCaseKeys', () => {
+  it('converts snake_case keys to PascalCase', () => {
+    expect(pascalCaseKeys({ user_name: 'Alice' })).toEqual({ UserName: 'Alice' });
+  });
+
+  it('recurses into nested plain objects', () => {
+    expect(pascalCaseKeys({ home_address: { zip_code: '12345' } })).toEqual({
+      HomeAddress: { ZipCode: '12345' },
+    });
+  });
+
+  it('recurses into arrays of objects', () => {
+    expect(pascalCaseKeys({ user_list: [{ first_name: 'A' }] })).toEqual({
+      UserList: [{ FirstName: 'A' }],
+    });
+  });
+
+  it('leaves already-PascalCase keys unchanged', () => {
+    expect(pascalCaseKeys({ UserName: 'Alice' })).toEqual({ UserName: 'Alice' });
+  });
+
+  it('handles an empty object', () => {
+    expect(pascalCaseKeys({})).toEqual({});
+  });
+
+  it('skips a dangerous key (constructor -> Constructor is safe, but literal constructor input is checked pre-transform via mapDeep)', () => {
+    // pascalCase('constructor') => 'Constructor', which is NOT itself a dangerous key —
+    // this documents that the danger only reappears if the *transformed* key collides,
+    // consistent with mapDeep checking the post-transform key.
+    expect(pascalCaseKeys({ constructor: 'x' })).toEqual({ Constructor: 'x' });
+  });
+});

--- a/helpers/object/pascalCaseKeys.ts
+++ b/helpers/object/pascalCaseKeys.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { pascalCase } from '../string/pascalCase.js';
+import { mapDeep } from './mapDeep.js';
+
+/**
+ * Recursively transforms every key of a plain object (including keys nested inside arrays and
+ * nested objects) to PascalCase. Handles camelCase, snake_case, kebab-case, and space-separated
+ * keys. Non-plain-object values — `Date`, `Map`, `Set`, class instances, primitives — are left
+ * untouched, only their position is walked into. An entry whose transformed key is a
+ * prototype-polluting string (`__proto__`, `constructor`, `prototype`) is silently skipped,
+ * same as the rest of `@helpers4/object`.
+ * @param value - The object (or array of objects) to transform
+ * @returns A new value with every plain-object key converted to PascalCase
+ * @example
+ * pascalCaseKeys({ user_name: 'Alice', home_address: { zip_code: '12345' } })
+ * // => { UserName: 'Alice', HomeAddress: { ZipCode: '12345' } }
+ * @since next
+ */
+export function pascalCaseKeys<T>(value: T): T {
+  return mapDeep(value, undefined, pascalCase);
+}

--- a/helpers/object/snakeCaseKeys.example.ts
+++ b/helpers/object/snakeCaseKeys.example.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { snakeCaseKeys } from './snakeCaseKeys';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'snakeCaseKeys',
+  category: 'object',
+  examples: [
+    {
+      title: 'Convert a camelCase object for a snake_case API',
+      description: 'Recursively converts every key, including nested objects, to snake_case.',
+      code: `snakeCaseKeys({ userName: 'Alice', homeAddress: { zipCode: '12345' } })
+// => { user_name: 'Alice', home_address: { zip_code: '12345' } }`,
+      assert: () => {
+        const result = snakeCaseKeys({ userName: 'Alice', homeAddress: { zipCode: '12345' } });
+        if (JSON.stringify(result) !== JSON.stringify({ user_name: 'Alice', home_address: { zip_code: '12345' } })) {
+          throw new Error('Unexpected result');
+        }
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/object/snakeCaseKeys.spec.ts
+++ b/helpers/object/snakeCaseKeys.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { snakeCaseKeys } from './snakeCaseKeys';
+
+describe('snakeCaseKeys — property-based', () => {
+  it('never produces more keys than the input (collisions can only shrink it)', () => {
+    fc.assert(
+      fc.property(fc.dictionary(fc.string({ minLength: 1 }).filter((s) => /[a-z]/i.test(s)), fc.integer()), (obj) => {
+        const result = snakeCaseKeys(obj);
+        expect(Object.keys(result).length).toBeLessThanOrEqual(Object.keys(obj).length);
+      }),
+    );
+  });
+
+  it('is idempotent on already-snake_case keys', () => {
+    fc.assert(
+      fc.property(fc.dictionary(fc.constantFrom('foo_bar', 'baz', 'qux_quux'), fc.integer()), (obj) => {
+        expect(snakeCaseKeys(obj)).toEqual(obj);
+      }),
+    );
+  });
+});
+
+describe('snakeCaseKeys — contract', () => {
+  it('empty object stays empty', () => {
+    expect(snakeCaseKeys({})).toEqual({});
+  });
+
+  it('primitives pass through unchanged', () => {
+    expect(snakeCaseKeys(42)).toBe(42);
+    expect(snakeCaseKeys(null)).toBe(null);
+  });
+});

--- a/helpers/object/snakeCaseKeys.test.ts
+++ b/helpers/object/snakeCaseKeys.test.ts
@@ -1,0 +1,52 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { snakeCaseKeys } from './snakeCaseKeys';
+
+describe('snakeCaseKeys', () => {
+  it('converts camelCase keys to snake_case', () => {
+    expect(snakeCaseKeys({ userName: 'Alice' })).toEqual({ user_name: 'Alice' });
+  });
+
+  it('recurses into nested plain objects', () => {
+    expect(snakeCaseKeys({ homeAddress: { zipCode: '12345' } })).toEqual({
+      home_address: { zip_code: '12345' },
+    });
+  });
+
+  it('recurses into arrays of objects', () => {
+    expect(snakeCaseKeys({ userList: [{ firstName: 'A' }] })).toEqual({
+      user_list: [{ first_name: 'A' }],
+    });
+  });
+
+  it('leaves already-snake_case keys unchanged', () => {
+    expect(snakeCaseKeys({ user_name: 'Alice' })).toEqual({ user_name: 'Alice' });
+  });
+
+  it('does not descend into non-plain-object values', () => {
+    const date = new Date('2026-01-01');
+    expect(snakeCaseKeys({ createdAt: date })).toEqual({ created_at: date });
+  });
+
+  it('handles an empty object', () => {
+    expect(snakeCaseKeys({})).toEqual({});
+  });
+
+  it('skips a dangerous key (__proto__, via JSON.parse)', () => {
+    const obj = JSON.parse('{"__proto__": "x", "a": 1}') as Record<string, unknown>;
+    expect(snakeCaseKeys(obj)).toEqual({ a: 1 });
+  });
+
+  it('skips a dangerous key (constructor)', () => {
+    expect(snakeCaseKeys({ constructor: 'x', a: 1 })).toEqual({ a: 1 });
+  });
+
+  it('skips a dangerous key (prototype)', () => {
+    expect(snakeCaseKeys({ prototype: 'x', a: 1 })).toEqual({ a: 1 });
+  });
+});

--- a/helpers/object/snakeCaseKeys.ts
+++ b/helpers/object/snakeCaseKeys.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { snakeCase } from '../string/snakeCase.js';
+import { mapDeep } from './mapDeep.js';
+
+/**
+ * Recursively transforms every key of a plain object (including keys nested inside arrays and
+ * nested objects) to snake_case. Handles camelCase, PascalCase, kebab-case, and space-separated
+ * keys. Non-plain-object values — `Date`, `Map`, `Set`, class instances, primitives — are left
+ * untouched, only their position is walked into. An entry whose transformed key is a
+ * prototype-polluting string (`__proto__`, `constructor`, `prototype`) is silently skipped,
+ * same as the rest of `@helpers4/object`.
+ * @param value - The object (or array of objects) to transform
+ * @returns A new value with every plain-object key converted to snake_case
+ * @example
+ * snakeCaseKeys({ userName: 'Alice', homeAddress: { zipCode: '12345' } })
+ * // => { user_name: 'Alice', home_address: { zip_code: '12345' } }
+ * @since next
+ */
+export function snakeCaseKeys<T>(value: T): T {
+  return mapDeep(value, undefined, snakeCase);
+}

--- a/helpers/object/sortKeys.example.ts
+++ b/helpers/object/sortKeys.example.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { sortKeys } from './sortKeys';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'sortKeys',
+  category: 'object',
+  examples: [
+    {
+      title: 'Sort object keys alphabetically',
+      description: 'Useful for stable JSON.stringify output or predictable snapshot tests.',
+      code: `sortKeys({ b: 2, a: 1, c: 3 })
+// => { a: 1, b: 2, c: 3 }`,
+      assert: () => {
+        const result = sortKeys({ b: 2, a: 1, c: 3 });
+        if (Object.keys(result).join(',') !== 'a,b,c') throw new Error('Unexpected key order');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/object/sortKeys.spec.ts
+++ b/helpers/object/sortKeys.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { UNSAFE_KEYS } from '../_shared/_unsafeKeys';
+import { sortKeys } from './sortKeys';
+
+// Integer-index-like keys ("0", "1", "42"...) are always iterated first by the JS engine,
+// in numeric order, regardless of insertion order — excluded here since no implementation
+// of sortKeys can override that language-level behavior. Prototype-polluting keys are also
+// excluded — sortKeys deliberately skips them (see sortKeys.test.ts), so a generic
+// "preserves every key" property doesn't hold for them.
+const nonIndexKey = fc
+  .string({ minLength: 1 })
+  .filter((s) => !/^(?:0|[1-9]\d*)$/.test(s) && !UNSAFE_KEYS.has(s));
+
+describe('sortKeys — property-based', () => {
+  it('never changes the set of keys or their values', () => {
+    fc.assert(
+      fc.property(fc.dictionary(nonIndexKey, fc.integer()), (obj) => {
+        const result = sortKeys(obj);
+        expect(result).toEqual(obj);
+      }),
+    );
+  });
+
+  it('resulting keys are in sorted order', () => {
+    fc.assert(
+      fc.property(fc.dictionary(nonIndexKey, fc.integer()), (obj) => {
+        const keys = Object.keys(sortKeys(obj));
+        expect(keys).toEqual([...keys].sort());
+      }),
+    );
+  });
+});
+
+describe('sortKeys — contract', () => {
+  it('empty object stays empty', () => {
+    expect(sortKeys({})).toEqual({});
+  });
+});

--- a/helpers/object/sortKeys.test.ts
+++ b/helpers/object/sortKeys.test.ts
@@ -1,0 +1,46 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { sortKeys } from './sortKeys';
+
+describe('sortKeys', () => {
+  it('sorts keys alphabetically by default', () => {
+    expect(Object.keys(sortKeys({ b: 2, a: 1, c: 3 }))).toEqual(['a', 'b', 'c']);
+  });
+
+  it('preserves the values for each key', () => {
+    expect(sortKeys({ b: 2, a: 1 })).toEqual({ a: 1, b: 2 });
+  });
+
+  it('accepts a custom comparator', () => {
+    expect(Object.keys(sortKeys({ a: 1, b: 2, c: 3 }, (a, b) => b.localeCompare(a)))).toEqual(['c', 'b', 'a']);
+  });
+
+  it('is shallow — nested object keys are not re-sorted', () => {
+    const result = sortKeys({ b: { z: 1, y: 2 }, a: 1 });
+    expect(Object.keys(result.b)).toEqual(['z', 'y']);
+  });
+
+  it('handles an empty object', () => {
+    expect(sortKeys({})).toEqual({});
+  });
+
+  it('does not mutate the input', () => {
+    const input = { b: 2, a: 1 };
+    sortKeys(input);
+    expect(Object.keys(input)).toEqual(['b', 'a']);
+  });
+
+  it('skips a dangerous key (__proto__, via JSON.parse)', () => {
+    const obj = JSON.parse('{"__proto__": 1, "a": 2}') as Record<string, number>;
+    expect(sortKeys(obj)).toEqual({ a: 2 });
+  });
+
+  it('skips a dangerous key (constructor)', () => {
+    expect(sortKeys({ constructor: 1, a: 2 })).toEqual({ a: 2 });
+  });
+});

--- a/helpers/object/sortKeys.ts
+++ b/helpers/object/sortKeys.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { UNSAFE_KEYS } from '../_shared/_unsafeKeys.js';
+
+/**
+ * Creates a new object with the same entries as the input, but with its own keys sorted.
+ * Shallow only — nested objects are copied as-is, their keys are not re-sorted.
+ * Key order matters for things like `JSON.stringify` diffs and snapshot stability; this does
+ * not change equality (`{a:1,b:2}` and `{b:2,a:1}` are already equal), just iteration/serialization order.
+ * Note: integer-index-like keys (`"0"`, `"1"`, `"42"`...) are always iterated first, in numeric
+ * order, by the JS engine itself — no object key ordering can override that language behavior.
+ * A prototype-polluting key (`__proto__`, `constructor`, `prototype`) is silently skipped,
+ * same as the rest of `@helpers4/object`.
+ * @param obj - The object whose keys to sort
+ * @param compareFn - Optional custom comparator, passed directly to `Array.prototype.sort`
+ * @returns A new object with the same entries, own keys in sorted order
+ * @example
+ * sortKeys({ b: 2, a: 1, c: 3 })
+ * // => { a: 1, b: 2, c: 3 }
+ * @since next
+ */
+export function sortKeys<T extends Record<string, unknown>>(
+  obj: T,
+  compareFn?: (a: string, b: string) => number,
+): T {
+  const sortedKeys = Object.keys(obj).toSorted(compareFn);
+  const result = {} as T;
+  for (const key of sortedKeys) {
+    if (UNSAFE_KEYS.has(key)) continue;
+    result[key as keyof T] = obj[key as keyof T];
+  }
+  return result;
+}

--- a/helpers/object/titleCaseKeys.example.ts
+++ b/helpers/object/titleCaseKeys.example.ts
@@ -1,0 +1,32 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { titleCaseKeys } from './titleCaseKeys';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'titleCaseKeys',
+  category: 'object',
+  examples: [
+    {
+      title: 'Convert object keys into display-friendly labels',
+      description: 'Recursively converts every key to Title Case — useful for form labels or table headers.',
+      code: `titleCaseKeys({ user_name: 'Alice', home_address: { zip_code: '12345' } })
+// => { 'User Name': 'Alice', 'Home Address': { 'Zip Code': '12345' } }`,
+      assert: () => {
+        const result = titleCaseKeys({ user_name: 'Alice', home_address: { zip_code: '12345' } });
+        if (
+          JSON.stringify(result) !==
+          JSON.stringify({ 'User Name': 'Alice', 'Home Address': { 'Zip Code': '12345' } })
+        ) {
+          throw new Error('Unexpected result');
+        }
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/object/titleCaseKeys.spec.ts
+++ b/helpers/object/titleCaseKeys.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { titleCaseKeys } from './titleCaseKeys';
+
+describe('titleCaseKeys — property-based', () => {
+  it('never produces more keys than the input (collisions can only shrink it)', () => {
+    fc.assert(
+      fc.property(fc.dictionary(fc.string({ minLength: 1 }).filter((s) => /[a-z]/i.test(s)), fc.integer()), (obj) => {
+        const result = titleCaseKeys(obj);
+        expect(Object.keys(result).length).toBeLessThanOrEqual(Object.keys(obj).length);
+      }),
+    );
+  });
+});
+
+describe('titleCaseKeys — contract', () => {
+  it('empty object stays empty', () => {
+    expect(titleCaseKeys({})).toEqual({});
+  });
+
+  it('primitives pass through unchanged', () => {
+    expect(titleCaseKeys(42)).toBe(42);
+    expect(titleCaseKeys(null)).toBe(null);
+  });
+});

--- a/helpers/object/titleCaseKeys.test.ts
+++ b/helpers/object/titleCaseKeys.test.ts
@@ -1,0 +1,30 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { titleCaseKeys } from './titleCaseKeys';
+
+describe('titleCaseKeys', () => {
+  it('converts snake_case keys to Title Case', () => {
+    expect(titleCaseKeys({ user_name: 'Alice' })).toEqual({ 'User Name': 'Alice' });
+  });
+
+  it('recurses into nested plain objects', () => {
+    expect(titleCaseKeys({ home_address: { zip_code: '12345' } })).toEqual({
+      'Home Address': { 'Zip Code': '12345' },
+    });
+  });
+
+  it('recurses into arrays of objects', () => {
+    expect(titleCaseKeys({ user_list: [{ first_name: 'A' }] })).toEqual({
+      'User List': [{ 'First Name': 'A' }],
+    });
+  });
+
+  it('handles an empty object', () => {
+    expect(titleCaseKeys({})).toEqual({});
+  });
+});

--- a/helpers/object/titleCaseKeys.ts
+++ b/helpers/object/titleCaseKeys.ts
@@ -1,0 +1,30 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { titleCase } from '../string/titleCase.js';
+import { mapDeep } from './mapDeep.js';
+
+/**
+ * Recursively transforms every key of a plain object (including keys nested inside arrays and
+ * nested objects) to Title Case. Handles camelCase, snake_case, kebab-case, and space-separated
+ * keys. Non-plain-object values — `Date`, `Map`, `Set`, class instances, primitives — are left
+ * untouched, only their position is walked into. An entry whose transformed key is a
+ * prototype-polluting string (`__proto__`, `constructor`, `prototype`) is silently skipped,
+ * same as the rest of `@helpers4/object`.
+ *
+ * Note: unlike the other `*CaseKeys` variants, `titleCase` joins words with spaces (e.g.
+ * `'User Name'`) — those keys are only usable via bracket access (`obj['User Name']`), not dot
+ * notation. Useful for display-facing structures (form labels, table headers), not wire formats.
+ * @param value - The object (or array of objects) to transform
+ * @returns A new value with every plain-object key converted to Title Case
+ * @example
+ * titleCaseKeys({ user_name: 'Alice', home_address: { zip_code: '12345' } })
+ * // => { 'User Name': 'Alice', 'Home Address': { 'Zip Code': '12345' } }
+ * @since next
+ */
+export function titleCaseKeys<T>(value: T): T {
+  return mapDeep(value, undefined, titleCase);
+}

--- a/helpers/set/config.json
+++ b/helpers/set/config.json
@@ -1,0 +1,5 @@
+{
+  "label": "Set",
+  "smallDescription": "Native Set manipulation utilities",
+  "description": "Utilities for working with native Set instances: iteration, filtering, transforming, and building Sets from arrays"
+}

--- a/helpers/set/countBy.example.ts
+++ b/helpers/set/countBy.example.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { countBy } from './countBy';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'countBy',
+  category: 'set',
+  examples: [
+    {
+      title: 'Count values by parity',
+      description: 'Groups values by a derived key and counts how many fall into each group.',
+      code: `countBy(new Set([1, 2, 3, 4]), v => v % 2 === 0 ? 'even' : 'odd')
+// => Map(2) { 'odd' => 2, 'even' => 2 }`,
+      assert: () => {
+        const result = countBy(new Set([1, 2, 3, 4]), (v) => (v % 2 === 0 ? 'even' : 'odd'));
+        if (result.get('odd') !== 2 || result.get('even') !== 2) throw new Error('Unexpected counts');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/set/countBy.spec.ts
+++ b/helpers/set/countBy.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { countBy } from './countBy';
+
+describe('countBy — property-based', () => {
+  it('sum of counts equals the set size', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer()), (values) => {
+        const set = new Set(values);
+        const counts = countBy(set, (v) => v % 3);
+        const total = [...counts.values()].reduce((a, b) => a + b, 0);
+        expect(total).toBe(set.size);
+      }),
+    );
+  });
+});
+
+describe('countBy — contract', () => {
+  it('empty set returns an empty map', () => {
+    expect(countBy(new Set(), () => 'x')).toEqual(new Map());
+  });
+});

--- a/helpers/set/countBy.test.ts
+++ b/helpers/set/countBy.test.ts
@@ -1,0 +1,20 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { countBy } from './countBy';
+
+describe('countBy', () => {
+  it('counts values per derived group', () => {
+    expect(countBy(new Set([1, 2, 3, 4]), (v) => (v % 2 === 0 ? 'even' : 'odd'))).toEqual(
+      new Map([['odd', 2], ['even', 2]]),
+    );
+  });
+
+  it('returns an empty map for an empty input', () => {
+    expect(countBy(new Set<number>(), (v) => v)).toEqual(new Map());
+  });
+});

--- a/helpers/set/countBy.ts
+++ b/helpers/set/countBy.ts
@@ -1,0 +1,24 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Groups the values of a Set by a derived key and counts how many fall into each group.
+ * @param set - The Set to summarize
+ * @param fn - Function deriving the grouping key from each value
+ * @returns A Map from derived key to the number of values in that group
+ * @example
+ * countBy(new Set([1, 2, 3, 4]), value => value % 2 === 0 ? 'even' : 'odd')
+ * // => Map(2) { 'odd' => 2, 'even' => 2 }
+ * @since next
+ */
+export function countBy<T, R>(set: ReadonlySet<T>, fn: (value: T) => R): Map<R, number> {
+  const counts = new Map<R, number>();
+  for (const value of set) {
+    const group = fn(value);
+    counts.set(group, (counts.get(group) ?? 0) + 1);
+  }
+  return counts;
+}

--- a/helpers/set/filter.example.ts
+++ b/helpers/set/filter.example.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { filter } from './filter';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'filter',
+  category: 'set',
+  examples: [
+    {
+      title: 'Keep only even values',
+      description: 'Creates a new Set with only the values that satisfy the predicate.',
+      code: `filter(new Set([1, 2, 3, 4]), value => value % 2 === 0)
+// => Set(2) { 2, 4 }`,
+      assert: () => {
+        const result = filter(new Set([1, 2, 3, 4]), (v) => v % 2 === 0);
+        if (result.size !== 2 || !result.has(2) || !result.has(4)) throw new Error('Unexpected result');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/set/filter.spec.ts
+++ b/helpers/set/filter.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { filter } from './filter';
+
+describe('filter — property-based', () => {
+  it('result size never exceeds the input size', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer()), (values) => {
+        const set = new Set(values);
+        expect(filter(set, (v) => v > 0).size).toBeLessThanOrEqual(set.size);
+      }),
+    );
+  });
+
+  it('every remaining value satisfies the predicate', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer()), (values) => {
+        const result = filter(new Set(values), (v) => v % 2 === 0);
+        for (const value of result) {
+          expect(value % 2 === 0).toBe(true);
+        }
+      }),
+    );
+  });
+});
+
+describe('filter — contract', () => {
+  it('empty set returns empty set', () => {
+    expect(filter(new Set(), () => true)).toEqual(new Set());
+  });
+});

--- a/helpers/set/filter.test.ts
+++ b/helpers/set/filter.test.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { filter } from './filter';
+
+describe('filter', () => {
+  it('keeps only values matching the predicate', () => {
+    expect(filter(new Set([1, 2, 3, 4]), (v) => v % 2 === 0)).toEqual(new Set([2, 4]));
+  });
+
+  it('returns an empty set when nothing matches', () => {
+    expect(filter(new Set([1]), () => false)).toEqual(new Set());
+  });
+
+  it('returns all values when everything matches', () => {
+    const set = new Set([1, 2]);
+    expect(filter(set, () => true)).toEqual(set);
+  });
+
+  it('does not mutate the original set', () => {
+    const set = new Set([1, 2]);
+    filter(set, (v) => v > 1);
+    expect(set.size).toBe(2);
+  });
+});

--- a/helpers/set/filter.ts
+++ b/helpers/set/filter.ts
@@ -1,0 +1,25 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Creates a new Set containing only the values for which the predicate returns true.
+ * @param set - The Set to filter
+ * @param predicate - Function invoked with each value — return true to keep it
+ * @returns A new Set with only the matching values
+ * @example
+ * filter(new Set([1, 2, 3, 4]), value => value % 2 === 0)
+ * // => Set(2) { 2, 4 }
+ * @since next
+ */
+export function filter<T>(set: ReadonlySet<T>, predicate: (value: T) => boolean): Set<T> {
+  const result = new Set<T>();
+  for (const value of set) {
+    if (predicate(value)) {
+      result.add(value);
+    }
+  }
+  return result;
+}

--- a/helpers/set/map.example.ts
+++ b/helpers/set/map.example.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { map } from './map';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'map',
+  category: 'set',
+  examples: [
+    {
+      title: 'Transform every value',
+      description: 'Creates a new Set with each value transformed by a function.',
+      code: `map(new Set([1, 2, 3]), value => value * 10)
+// => Set(3) { 10, 20, 30 }`,
+      assert: () => {
+        const result = map(new Set([1, 2, 3]), (value) => value * 10);
+        if (![...result].every((v) => [10, 20, 30].includes(v))) throw new Error('Unexpected result');
+      },
+    },
+    {
+      title: 'Duplicates collapse',
+      description: 'If two values transform to the same result, the Set naturally deduplicates.',
+      code: `map(new Set([1, 2, 3]), () => 'same')
+// => Set(1) { 'same' }`,
+      assert: () => {
+        const result = map(new Set([1, 2, 3]), () => 'same');
+        if (result.size !== 1) throw new Error('Expected duplicates to collapse');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/set/map.spec.ts
+++ b/helpers/set/map.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { map } from './map';
+
+describe('map — property-based', () => {
+  it('result size never exceeds the input size (duplicates can only shrink it)', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer()), (values) => {
+        const set = new Set(values);
+        expect(map(set, (v) => v % 5).size).toBeLessThanOrEqual(set.size);
+      }),
+    );
+  });
+
+  it('identity transform preserves the set', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer()), (values) => {
+        const set = new Set(values);
+        expect(map(set, (v) => v)).toEqual(set);
+      }),
+    );
+  });
+});
+
+describe('map — contract', () => {
+  it('empty set returns an empty set', () => {
+    expect(map(new Set<number>(), (v) => v)).toEqual(new Set());
+  });
+});

--- a/helpers/set/map.test.ts
+++ b/helpers/set/map.test.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { map } from './map';
+
+describe('map', () => {
+  it('transforms every value', () => {
+    expect(map(new Set([1, 2, 3]), (v) => v * 10)).toEqual(new Set([10, 20, 30]));
+  });
+
+  it('collapses duplicates produced by the transform', () => {
+    expect(map(new Set([1, 2, 3]), () => 'same')).toEqual(new Set(['same']));
+  });
+
+  it('returns an empty set for an empty input', () => {
+    expect(map(new Set<number>(), (v) => v)).toEqual(new Set());
+  });
+});

--- a/helpers/set/map.ts
+++ b/helpers/set/map.ts
@@ -1,0 +1,24 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Creates a new Set with each value transformed by a function. If two values transform to the
+ * same result, duplicates collapse — the returned Set may be smaller than the input.
+ * @param set - The Set to transform
+ * @param fn - Function invoked with each value, returning the new value
+ * @returns A new Set of transformed values
+ * @example
+ * map(new Set([1, 2, 3]), value => value * 10)
+ * // => Set(3) { 10, 20, 30 }
+ * @since next
+ */
+export function map<T, R>(set: ReadonlySet<T>, fn: (value: T) => R): Set<R> {
+  const result = new Set<R>();
+  for (const value of set) {
+    result.add(fn(value));
+  }
+  return result;
+}

--- a/helpers/set/toMapByKey.example.ts
+++ b/helpers/set/toMapByKey.example.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { toMapByKey } from './toMapByKey';
+import type { HelperExamples } from '../../scripts/examples/types';
+
+const examples: HelperExamples = {
+  helper: 'toMapByKey',
+  category: 'set',
+  examples: [
+    {
+      title: 'Turn a Set into a lookup Map',
+      description: 'Builds a Map keyed by a derived value, for O(1) lookup by that key.',
+      code: `toMapByKey(new Set([{ id: 'a' }, { id: 'b' }]), item => item.id)
+// => Map(2) { 'a' => {...}, 'b' => {...} }`,
+      assert: () => {
+        const map = toMapByKey(new Set([{ id: 'a' }, { id: 'b' }]), (item) => item.id);
+        if (!map.has('a') || !map.has('b')) throw new Error('Unexpected lookup result');
+      },
+    },
+  ],
+};
+
+export default examples;

--- a/helpers/set/toMapByKey.spec.ts
+++ b/helpers/set/toMapByKey.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { toMapByKey } from './toMapByKey';
+
+describe('toMapByKey — property-based', () => {
+  it('result size never exceeds the input size', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer()), (values) => {
+        const set = new Set(values);
+        expect(toMapByKey(set, (n) => n % 5).size).toBeLessThanOrEqual(set.size);
+      }),
+    );
+  });
+});
+
+describe('toMapByKey — contract', () => {
+  it('empty set returns an empty map', () => {
+    expect(toMapByKey(new Set<never>(), (x) => x)).toEqual(new Map());
+  });
+});

--- a/helpers/set/toMapByKey.test.ts
+++ b/helpers/set/toMapByKey.test.ts
@@ -1,0 +1,21 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { toMapByKey } from './toMapByKey';
+
+describe('toMapByKey', () => {
+  it('indexes values by a derived key', () => {
+    const set = new Set([{ id: 'a', n: 1 }, { id: 'b', n: 2 }]);
+    expect(toMapByKey(set, (item) => item.id)).toEqual(
+      new Map([['a', { id: 'a', n: 1 }], ['b', { id: 'b', n: 2 }]]),
+    );
+  });
+
+  it('returns an empty map for an empty input', () => {
+    expect(toMapByKey(new Set<never>(), (x) => x)).toEqual(new Map());
+  });
+});

--- a/helpers/set/toMapByKey.ts
+++ b/helpers/set/toMapByKey.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of helpers4.
+ * Copyright (C) 2025 baxyz
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Builds a Map from a Set, keyed by a derived key. When two values derive the same key,
+ * the later value (in iteration order) wins (last-write-wins, matching `Map.prototype.set`).
+ *
+ * Named `toMapByKey`, not `keyBy` (lodash's name for the same idea) — lodash's `_.keyBy`
+ * returns a plain object, not a `Map`; the `to<Type>` prefix (matching `toSorted`/`toReversed`)
+ * makes the actual return type unambiguous.
+ * @param set - The Set to index
+ * @param fn - Function deriving the key for each value
+ * @returns A Map from derived key to value
+ * @example
+ * toMapByKey(new Set([{ id: 'a' }, { id: 'b' }]), item => item.id)
+ * // => Map(2) { 'a' => { id: 'a' }, 'b' => { id: 'b' } }
+ * @since next
+ */
+export function toMapByKey<T, K>(set: ReadonlySet<T>, fn: (value: T) => K): Map<K, T> {
+  const result = new Map<K, T>();
+  for (const value of set) {
+    result.set(fn(value), value);
+  }
+  return result;
+}

--- a/helpers/string/camelCase.spec.ts
+++ b/helpers/string/camelCase.spec.ts
@@ -9,21 +9,26 @@ import { describe, expect, it } from 'vitest';
 import { camelCase } from './camelCase';
 
 describe('camelCase — property-based', () => {
-  it('result contains no -[a-z] patterns (the only pattern converted)', () => {
+  it('result contains no separator characters (space/underscore/hyphen)', () => {
     fc.assert(
       fc.property(fc.string(), (str) => {
-        expect(camelCase(str)).not.toMatch(/-[a-z]/);
+        expect(camelCase(str)).not.toMatch(/[\s_-]/);
       }),
     );
   });
 
-  it('result length is <= input length (hyphens removed, no new chars added)', () => {
+  it('result length is <= input length (separators removed, no new chars added)', () => {
     fc.assert(
       fc.property(fc.string(), (str) => {
         expect(camelCase(str).length).toBeLessThanOrEqual(str.length);
       }),
     );
   });
+
+  // Not idempotent in general: input with punctuation glued to a letter (e.g. '! A' -> '!A')
+  // re-lowercases that letter on a second pass, since it becomes the "first word" — the same
+  // pre-existing edge case pascalCase/titleCase already have with their identical split-based
+  // approach, not something specific to this fix.
 });
 
 describe('camelCase — contract', () => {
@@ -51,14 +56,11 @@ describe('camelCase — contract', () => {
     expect(camelCase('alreadycamel')).toBe('alreadycamel');
   });
 
-  it('uppercase letter after hyphen is NOT uppercased (only lowercase matched)', () => {
-    // The regex is /-([a-z])/ so uppercase after hyphen is not changed
-    expect(camelCase('UPPER-CASE')).toBe('UPPER-CASE');
+  it('splits on hyphens regardless of the case of what follows', () => {
+    expect(camelCase('UPPER-CASE')).toBe('upperCase');
   });
 
-  it('leading dashes remain, and subsequent -[a-z] patterns are converted', () => {
-    // '--leading-dashes': '-l' and '-d' match, '-' before 'l' is consumed
-    // Result: '-LeadingDashes' (the leading '--' has one '-' consumed by the '-l' match)
-    expect(camelCase('--leading-dashes')).toBe('-LeadingDashes');
+  it('collapses leading/multiple dashes instead of leaving them in the output', () => {
+    expect(camelCase('--leading-dashes')).toBe('leadingDashes');
   });
 });

--- a/helpers/string/camelCase.test.ts
+++ b/helpers/string/camelCase.test.ts
@@ -29,7 +29,29 @@ describe("camelCase", () => {
   });
 
   it("should handle leading dash", () => {
-    expect(camelCase("-leading")).toBe("Leading");
+    expect(camelCase("-leading")).toBe("leading");
+  });
+
+  it("should convert snake_case to camelCase", () => {
+    expect(camelCase("user_name")).toBe("userName");
+  });
+
+  it("should convert PascalCase to camelCase", () => {
+    expect(camelCase("UserName")).toBe("userName");
+  });
+
+  it("should convert space-separated words to camelCase", () => {
+    expect(camelCase("user name")).toBe("userName");
+  });
+
+  it("should handle mixed separators", () => {
+    expect(camelCase("user_name-here too")).toBe("userNameHereToo");
+  });
+
+  it("should treat an embedded acronym as a word boundary, lowercasing all but its last letter", () => {
+    expect(camelCase("userID")).toBe("userId");
+    expect(camelCase("parseHTMLString")).toBe("parseHtmlString");
+    expect(camelCase("apiURL")).toBe("apiUrl");
   });
 
   it('should return null when given null', () => {

--- a/helpers/string/camelCase.ts
+++ b/helpers/string/camelCase.ts
@@ -5,9 +5,21 @@
  */
 
 /**
- * Converts kebab-case to camelCase
- * @param str - The kebab-case string to convert
+ * Converts a string to camelCase.
+ * Handles PascalCase, kebab-case, snake_case, spaces, and mixed formats.
+ *
+ * An embedded run of capitals is treated as an acronym boundary: only its last letter starts
+ * the next word, the rest are lowercased (matching lodash's `camelCase` convention) — so an
+ * already-camelCase identifier containing an acronym is not left untouched.
+ * @param str - The string to convert
  * @returns String in camelCase
+ * @example
+ * camelCase('hello-world')
+ * // => 'helloWorld'
+ * camelCase('user_name')
+ * // => 'userName'
+ * camelCase('userID')
+ * // => 'userId' (acronym boundary, not left as-is)
  * @since 1.9.0
  */
 export function camelCase(str: string): string;
@@ -15,5 +27,17 @@ export function camelCase(str: undefined): undefined;
 export function camelCase(str: null): null;
 export function camelCase(str: string | undefined | null): string | undefined | null {
   if (str === undefined || str === null) return str;
-  return str.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+  const words = str
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2')
+    .split(/[\s_-]+/)
+    .filter(Boolean);
+  if (words.length === 0) return '';
+  return (
+    words[0]!.toLowerCase() +
+    words
+      .slice(1)
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join('')
+  );
 }

--- a/helpers/string/kebabCase.spec.ts
+++ b/helpers/string/kebabCase.spec.ts
@@ -25,6 +25,14 @@ describe('kebabCase — property-based', () => {
       }),
     );
   });
+
+  it('never starts/ends with a hyphen and never has consecutive hyphens', () => {
+    fc.assert(
+      fc.property(fc.string(), (str) => {
+        expect(kebabCase(str)).not.toMatch(/^-|-$|--/);
+      }),
+    );
+  });
 });
 
 describe('kebabCase — contract', () => {
@@ -54,5 +62,18 @@ describe('kebabCase — contract', () => {
 
   it('already lowercase string unchanged', () => {
     expect(kebabCase('alreadykebab')).toBe('alreadykebab');
+  });
+
+  it('snake_case converts correctly', () => {
+    expect(kebabCase('user_name')).toBe('user-name');
+  });
+
+  it('is idempotent — applying it twice equals applying it once', () => {
+    fc.assert(
+      fc.property(fc.string(), (str) => {
+        const once = kebabCase(str);
+        expect(kebabCase(once)).toBe(once);
+      }),
+    );
   });
 });

--- a/helpers/string/kebabCase.test.ts
+++ b/helpers/string/kebabCase.test.ts
@@ -33,6 +33,28 @@ describe("kebabCase", () => {
     expect(kebabCase("Hello")).toBe("hello");
   });
 
+  it("should convert snake_case to kebab-case", () => {
+    expect(kebabCase("user_name")).toBe("user-name");
+  });
+
+  it("should convert space-separated words to kebab-case", () => {
+    expect(kebabCase("user name")).toBe("user-name");
+  });
+
+  it("should handle mixed separators", () => {
+    expect(kebabCase("user_name here")).toBe("user-name-here");
+  });
+
+  it("should not produce leading/trailing hyphens for leading/trailing separators", () => {
+    expect(kebabCase("  leading spaces")).toBe("leading-spaces");
+    expect(kebabCase("trailing  ")).toBe("trailing");
+    expect(kebabCase("_id")).toBe("id");
+  });
+
+  it("should not produce a double hyphen for adjacent separators", () => {
+    expect(kebabCase("foo_-bar")).toBe("foo-bar");
+  });
+
   it('should return null when given null', () => {
     expect(kebabCase(null)).toBeNull();
   });

--- a/helpers/string/kebabCase.ts
+++ b/helpers/string/kebabCase.ts
@@ -5,9 +5,15 @@
  */
 
 /**
- * Converts camelCase to kebab-case
- * @param str - The camelCase string to convert
+ * Converts a string to kebab-case.
+ * Handles camelCase, PascalCase, snake_case, spaces, and mixed formats.
+ * @param str - The string to convert
  * @returns String in kebab-case
+ * @example
+ * kebabCase('camelCase')
+ * // => 'camel-case'
+ * kebabCase('user_name')
+ * // => 'user-name'
  * @since 1.9.0
  */
 export function kebabCase(str: string): string;
@@ -15,8 +21,10 @@ export function kebabCase(str: undefined): undefined;
 export function kebabCase(str: null): null;
 export function kebabCase(str: string | undefined | null): string | undefined | null {
   if (str === undefined || str === null) return str;
-  return str
-    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
-    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
-    .toLowerCase();
+  const words = str
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2')
+    .split(/[\s_-]+/)
+    .filter(Boolean);
+  return words.join('-').toLowerCase();
 }

--- a/scopes.json
+++ b/scopes.json
@@ -10,6 +10,7 @@
   "function",
   "guard",
   "id",
+  "map",
   "markdown",
   "node",
   "number",

--- a/scopes.json
+++ b/scopes.json
@@ -20,6 +20,7 @@
   "release",
   "scorecard",
   "security",
+  "set",
   "shared",
   "string",
   "type",


### PR DESCRIPTION
Researched active lodash/ramda-style competitors beyond radashi/remeda (es-toolkit, rambda, moderndash — full comparisons now in the website repo) and distilled what's actually missing from helpers4, prioritized:

- 🔴 Map/Set utilities — a whole missing category (only guards exist today), found via es-toolkit's full Map/Set utility sets
- 🟡 concurrency primitives in @helpers4/promise (delay, withTimeout, Mutex/Semaphore) — converges across es-toolkit AND moderndash independently, a stronger signal than a single library having it
- 🟡 median/percentile/*By number stats — cheap, well-scoped, good first-timer candidate
- 🟢 bulk object-key case transforms, async-aware array iteration (flagged as needing a design discussion, not a clear add), and a handful of narrower environment/JSON guards

@mobily/ts-belt checked and excluded (last published 2023-01-10). Effect-TS excluded as a different category (FP platform, not a utility library).

## Description

Please include a summary of what this PR does and why it's needed.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test improvement

## Related Issues

Closes #(issue number)

## How Has This Been Tested?

Describe the tests you ran and how to reproduce them:
- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests for my changes
- [ ] All new and existing tests passed locally
- [ ] My commits follow the conventional commit format

## Screenshots (if applicable)

Add screenshots for UI changes.

## Additional Context

Add any other context about the PR here.
