### PR TITLE
refactor(CI-CD): adopt helpers4/action setup-pnpm/pr-status-comment/trigger-website-update

### DIFF
--- a/.github/workflows/job-bench.yml
+++ b/.github/workflows/job-bench.yml
@@ -39,16 +39,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - name: Setup pnpm
+        uses: helpers4/action/setup-pnpm@215739f023134ab5ed2158607074084ec530a830
         with:
           node-version: ${{ inputs.node-version }}
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Detect changed bench targets
         id: changed

--- a/.github/workflows/job-build.yml
+++ b/.github/workflows/job-build.yml
@@ -32,16 +32,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - name: Setup pnpm
+        uses: helpers4/action/setup-pnpm@215739f023134ab5ed2158607074084ec530a830
         with:
           node-version: ${{ inputs.node-version }}
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Build project
         id: build

--- a/.github/workflows/job-lint.yml
+++ b/.github/workflows/job-lint.yml
@@ -24,16 +24,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - name: Setup pnpm
+        uses: helpers4/action/setup-pnpm@215739f023134ab5ed2158607074084ec530a830
         with:
           node-version: ${{ inputs.node-version }}
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Run linting
         id: lint

--- a/.github/workflows/job-security.yml
+++ b/.github/workflows/job-security.yml
@@ -28,16 +28,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - name: Setup pnpm
+        uses: helpers4/action/setup-pnpm@215739f023134ab5ed2158607074084ec530a830
         with:
           node-version: ${{ inputs.node-version }}
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Run security audit
         id: security

--- a/.github/workflows/job-tests.yml
+++ b/.github/workflows/job-tests.yml
@@ -51,16 +51,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - name: Setup pnpm
+        uses: helpers4/action/setup-pnpm@215739f023134ab5ed2158607074084ec530a830
         with:
           node-version: ${{ inputs.node-version }}
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Run unit tests
         id: test

--- a/.github/workflows/job-typecheck.yml
+++ b/.github/workflows/job-typecheck.yml
@@ -24,16 +24,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - name: Setup pnpm
+        uses: helpers4/action/setup-pnpm@215739f023134ab5ed2158607074084ec530a830
         with:
           node-version: ${{ inputs.node-version }}
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Run TypeScript check
         id: typecheck

--- a/.github/workflows/job-verification.yml
+++ b/.github/workflows/job-verification.yml
@@ -27,16 +27,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - name: Setup pnpm
+        uses: helpers4/action/setup-pnpm@215739f023134ab5ed2158607074084ec530a830
         with:
           node-version: ${{ inputs.node-version }}
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -208,7 +208,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
+      pull-requests: write
     needs:
       [
         version-calculation,

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -37,16 +37,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - name: Setup pnpm
+        uses: helpers4/action/setup-pnpm@215739f023134ab5ed2158607074084ec530a830
         with:
           node-version: ${{ env.NODE_LATEST_LTS }}
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Get current version
         id: version
@@ -94,23 +88,12 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    outputs:
-      status: ${{ steps.status.outputs.status }}
     steps:
       - name: Check conventional commits
         uses: helpers4/action/conventional-commits@397ddbfecdab62efa1416012576b165abf2d7ee4
         with:
           checkout: "true"
           pr-comment: "error"
-      - name: Set status
-        id: status
-        if: always()
-        run: |
-          if [ ${{ job.status }} == 'success' ]; then
-            echo "status=success" >> $GITHUB_OUTPUT
-          else
-            echo "status=failure" >> $GITHUB_OUTPUT
-          fi
 
   # Runtime compatibility (Node, Deno, Bun)
   runtime-compat:
@@ -129,16 +112,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - name: Setup pnpm
+        uses: helpers4/action/setup-pnpm@215739f023134ab5ed2158607074084ec530a830
         with:
           node-version: ${{ env.NODE_LATEST_LTS }}
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Setup Deno
         uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed
@@ -204,16 +181,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - name: Setup pnpm
+        uses: helpers4/action/setup-pnpm@215739f023134ab5ed2158607074084ec530a830
         with:
           node-version: ${{ env.NODE_LATEST_LTS }}
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Run mutation tests
         id: mutation
@@ -255,25 +226,11 @@ jobs:
     if: always()
 
     steps:
-      - name: Update PR comment
+      - name: Build extra sections
+        id: extra
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const createJobsTable = (jobs) => {
-              const rows = Object.entries(jobs).map(([job, status]) => {
-                const icon = status === 'success' ? '✅' :
-                           status === 'failure' ? '❌' :
-                           status === 'skipped' ? '⏭️' : '⚠️';
-                const statusBadge = status === 'success' ? '`passing`' :
-                                   status === 'failure' ? '`failing`' :
-                                   status === 'skipped' ? '`skipped`' : '`unknown`';
-                return `| ${icon} | **${job}** | ${statusBadge} |`;
-              }).join('\n');
-
-              return `| | Job | Status |\n|:---:|-----|:------:|\n${rows}`;
-            };
-
             const createCoverageSection = (coverage) => {
               const target = 100;
               const getStatus = (value) => {
@@ -325,17 +282,6 @@ jobs:
                 '',
                 '> 🧬 *Informational only, does not block the PR*',
               ].join('\n');
-            };
-
-            const jobs = {
-              '🔢 Version': "${{ needs.version-calculation.outputs.status || 'unknown' }}",
-              '🏗️ Build': "${{ needs.build.outputs.status || 'unknown' }}",
-              '🧪 Tests': "${{ needs.test.outputs.status || 'unknown' }}",
-              '📝 Lint': "${{ needs.lint.outputs.status || 'unknown' }}",
-              '📘 TypeCheck': "${{ needs.type-check.outputs.status || 'unknown' }}",
-              '🔐 Security Audit': "${{ needs.security.outputs.status || 'unknown' }}",
-              '🧾 Conventional Commits': "${{ needs.conventional-commits.outputs.status || 'unknown' }}",
-              '🔗 Coherency': "${{ needs.verification.outputs.status || 'unknown' }}",
             };
 
             const coverage = {
@@ -398,29 +344,7 @@ jobs:
               ].join('\n');
             };
 
-            const passedCount = Object.values(jobs).filter(s => s === 'success').length;
-            const totalJobs = Object.keys(jobs).length;
-            const allPassed = passedCount === totalJobs;
-            const avgCoverage = (Object.values(coverage).reduce((a, b) => a + parseFloat(b), 0) / 4).toFixed(1);
-            const coverageOk = parseFloat(avgCoverage) >= 100;
-
-            const statusBanner = allPassed && coverageOk
-              ? '## ✅ PR Validation Passed\n\n> All checks passed and coverage target reached!'
-              : allPassed
-                ? `## 🟡 PR Validation Passed\n\n> All checks passed • Coverage: ${avgCoverage}% (target: 100%)`
-                : `## ❌ PR Validation Failed\n\n> ${passedCount}/${totalJobs} checks passed`;
-
-            const comment = `${statusBanner}
-
-            ---
-
-            ### 📋 Pipeline Status
-
-            ${createJobsTable(jobs)}
-
-            ---
-
-            ### 📊 Code Coverage
+            const extraMarkdown = `### 📊 Code Coverage
 
             ${createCoverageSection(coverage)}
 
@@ -453,40 +377,22 @@ jobs:
             - 🔄 This comment updates automatically with each push
             - 📈 Coverage is measured using Vitest + v8
 
-            </details>
+            </details>`;
 
-            <sub>🤖 Generated by **@helpers4** CI • ${new Date().toISOString().split('T')[0]}</sub>`;
+            core.setOutput('markdown', extraMarkdown);
 
-            try {
-              const { data: comments } = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-              });
-
-              const botComment = comments.find(comment =>
-                comment.user.type === 'Bot' && comment.body.includes('PR Validation')
-              );
-
-              if (botComment) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: botComment.id,
-                  body: comment
-                });
-                console.log('Updated existing comment');
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body: comment
-                });
-                console.log('Created new comment');
-              }
-            } catch (error) {
-              console.error('Error updating PR comment:', error);
-              console.log('Comment update failed, but continuing workflow...');
+      - name: Update PR comment
+        uses: helpers4/action/pr-status-comment@215739f023134ab5ed2158607074084ec530a830
+        with:
+          jobs: |
+            {
+              "🔢 Version": "${{ needs.version-calculation.outputs.status || 'unknown' }}",
+              "🏗️ Build": "${{ needs.build.outputs.status || 'unknown' }}",
+              "🧪 Tests": "${{ needs.test.outputs.status || 'unknown' }}",
+              "📝 Lint": "${{ needs.lint.outputs.status || 'unknown' }}",
+              "📘 TypeCheck": "${{ needs.type-check.outputs.status || 'unknown' }}",
+              "🔐 Security Audit": "${{ needs.security.outputs.status || 'unknown' }}",
+              "🧾 Conventional Commits": "${{ needs.conventional-commits.result }}",
+              "🔗 Coherency": "${{ needs.verification.outputs.status || 'unknown' }}"
             }
-            return true;
+          extra-markdown: ${{ steps.extra.outputs.markdown }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,52 +389,12 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - name: Get Trigganator token
-        id: trigganator
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
-        with:
-          client-id: ${{ vars.TRIGGANATOR_ID }}
-          private-key: ${{ secrets.TRIGGANATOR_KEY }}
-          owner: helpers4
-          repositories: website
-          permission-contents: write
-
       - name: Trigger website docs update
-        id: trigger_docs_primary
-        continue-on-error: true
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
+        uses: helpers4/action/trigger-website-update@215739f023134ab5ed2158607074084ec530a830
         with:
-          token: ${{ steps.trigganator.outputs.token }}
-          repository: helpers4/website
           event-type: typescript-release
-          client-payload: '{"version": "${{ needs.publish.outputs.new-version }}"}'
-
-      - name: Get Pushinator token fallback
-        if: steps.trigger_docs_primary.outcome != 'success'
-        id: pushinator_fallback
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
-        with:
-          client-id: ${{ vars.PUSHINATOR_ID }}
-          private-key: ${{ secrets.PUSHINATOR_KEY }}
-          owner: helpers4
-          repositories: website
-          permission-contents: write
-
-      - name: Retry website docs update with fallback token
-        if: steps.trigger_docs_primary.outcome != 'success'
-        id: trigger_docs_fallback
-        continue-on-error: true
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
-        with:
-          token: ${{ steps.pushinator_fallback.outputs.token }}
-          repository: helpers4/website
-          event-type: typescript-release
-          client-payload: '{"version": "${{ needs.publish.outputs.new-version }}"}'
-
-      - name: Trigger summary
-        run: |
-          if [ "${{ steps.trigger_docs_primary.outcome }}" = "success" ] || [ "${{ steps.trigger_docs_fallback.outcome }}" = "success" ]; then
-            echo "✅ Website docs trigger dispatched for v${{ needs.publish.outputs.new-version }}"
-          else
-            echo "⚠️  Website docs trigger failed (non-blocking) for v${{ needs.publish.outputs.new-version }}"
-          fi
+          payload: '{"version": "${{ needs.publish.outputs.new-version }}"}'
+          app-id: ${{ vars.TRIGGANATOR_ID }}
+          app-private-key: ${{ secrets.TRIGGANATOR_KEY }}
+          fallback-app-id: ${{ vars.PUSHINATOR_ID }}
+          fallback-app-private-key: ${{ secrets.PUSHINATOR_KEY }}


### PR DESCRIPTION
## Summary
- All 7 `job-*.yml` reusable workflows (`job-build`, `job-lint`, `job-typecheck`, `job-tests`, `job-security`, `job-bench`, `job-verification`): `checkout → setup-node → corepack enable → pnpm install --frozen-lockfile` collapses into one `helpers4/action/setup-pnpm@<sha>` call each (pinned to a commit SHA, matching this repo's existing security posture — every other repo uses `@main`, this one pins everything)
- `pr-validation.yml`:
  - `version-calculation`, `runtime-compat`, `mutation` jobs get the same `setup-pnpm` swap for their inline setup sequence
  - `conventional-commits`' dead "Set status" boilerplate removed (the only instance of that antipattern in this file — the other jobs' `outputs.status` are real values computed from their own step logic, not blind `job.status` mirrors, so those are untouched)
  - The huge status-comment `actions/github-script` block is split in two: a "Build extra sections" step keeps the existing coverage/mutation/runtime-compat/bench Markdown-building logic verbatim (same progress bars, same thresholds, same wording) and exposes it as an output; a new "Update PR comment" step calls `helpers4/action/pr-status-comment` with the 8 core job statuses + that output as `extra-markdown` — so none of the rich formatting is lost, only the comment-posting plumbing is delegated
- `release.yml`: the `trigger-website-docs` job's primary-token + `peter-evans/repository-dispatch` + Pushinator-fallback-token + retry-dispatch (4 steps) collapses into one `helpers4/action/trigger-website-update` call with both `app-id`/`app-private-key` (Trigganator) and `fallback-app-id`/`fallback-app-private-key` (Pushinator) — same retry behavior, now built into the action instead of hand-rolled here
- Net: −176 lines across 9 files, no intended behavior change

## Test plan
- [ ] CI: full `pr-validation.yml` run (build/test/lint/typecheck/security/verification/mutation/runtime-compat/bench/conventional-commits + the new pr-status-comment)
- [ ] Manually verify the sticky PR comment renders with all sections (coverage bars, mutation status, runtime compat table, bench summary) intact
- [ ] `release.yml`'s `trigger-website-docs` job isn't exercised by PR CI (only runs on actual release) — first real validation is the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)