### PR TITLE
refactor: adopt renamed dispatch-with-fallback action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,8 +390,10 @@ jobs:
 
     steps:
       - name: Trigger website docs update
-        uses: helpers4/action/trigger-website-update@215739f023134ab5ed2158607074084ec530a830
+        uses: helpers4/action/dispatch-with-fallback@655d5518ee59c3181234460c5b4bbc7ae47ed86d
         with:
+          target-owner: helpers4
+          target-repo: website
           event-type: typescript-release
           payload: '{"version": "${{ needs.publish.outputs.new-version }}"}'
           app-id: ${{ vars.TRIGGANATOR_ID }}


### PR DESCRIPTION
## Summary
- `helpers4/action`'s `trigger-website-update` was renamed to `dispatch-with-fallback` and genericized (no more `helpers4`/`website` defaults — [helpers4/action#15](https://github.com/helpers4/action/pull/15)). Updates `release.yml`'s `trigger-website-docs` job to the new name + explicit `target-owner`/`target-repo` inputs, matching this repo's SHA-pinning convention.
- **SHA pin note**: pinned to `655d5518ee59c3181234460c5b4bbc7ae47ed86d` — the commit on #15's branch, since #15 isn't merged yet. This `release.yml` isn't exercised by PR CI (it's `workflow_dispatch`-only), so this doesn't block this PR going green, but **please update the pin to `main`'s SHA after #15 merges**, before the next actual release run — a feature-branch commit isn't a reliable long-term pin if that branch gets deleted post-merge.

## Test plan
- [ ] CI green (this file isn't exercised by `pr-validation.yml`)
- [ ] Follow-up: re-pin to `main`'s SHA once #15 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)