### PR TITLE
fix: re-pin dispatch-with-fallback to main SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,7 +390,7 @@ jobs:
 
     steps:
       - name: Trigger website docs update
-        uses: helpers4/action/dispatch-with-fallback@655d5518ee59c3181234460c5b4bbc7ae47ed86d
+        uses: helpers4/action/dispatch-with-fallback@c66ddc3b4c9c46c4c3f4b9a8c87e16bb188321bd
         with:
           target-owner: helpers4
           target-repo: website


### PR DESCRIPTION
## Summary
- Follow-up to #125: that PR pinned `dispatch-with-fallback` to the commit SHA on `helpers4/action#15`'s feature branch (since #15 wasn't merged yet). #15 is now merged — re-pins to `main`'s actual SHA (`c66ddc3b4c9c46c4c3f4b9a8c87e16bb188321bd`) instead of the feature-branch commit, which isn't a reliable long-term reference once that branch is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)